### PR TITLE
Refactor enums to use Pascal Case

### DIFF
--- a/src/emission.rs
+++ b/src/emission.rs
@@ -48,34 +48,34 @@ fn emit_instructions(
 ) {
     for instruction in instructions {
         match instruction {
-            assembly::Instruction::MOV(src, dst) => {
+            assembly::Instruction::Mov(src, dst) => {
                 let src = get_operand(src);
                 let dst = get_operand(dst);
                 writeln!(file, "    movl {src}, {dst}").unwrap();
             }
-            assembly::Instruction::RET => {
+            assembly::Instruction::Ret => {
                 writeln!(file, "    movq %rbp, %rsp").unwrap();
                 writeln!(file, "    popq %rbp").unwrap();
                 writeln!(file, "    ret").unwrap();
             }
-            assembly::Instruction::STACKALLOCATE(val) => {
+            assembly::Instruction::StackAllocate(val) => {
                 writeln!(file, "    subq ${}, %rsp", val).unwrap();
             }
-            assembly::Instruction::STACKDEALLOCATE(val) => {
+            assembly::Instruction::StackDeallocate(val) => {
                 writeln!(file, "    addq ${}, %rsp", val).unwrap();
             }
-            assembly::Instruction::UNARY(operator, operand) => {
+            assembly::Instruction::Unary(operator, operand) => {
                 let operator = get_unary_operator(operator);
                 let operand = get_operand(operand);
                 writeln!(file, "    {} {}", operator, operand).unwrap();
             }
-            assembly::Instruction::CDQ => {
+            assembly::Instruction::Cdq => {
                 writeln!(file, "    cdq").unwrap();
             }
-            assembly::Instruction::IDIV(operand) => {
+            assembly::Instruction::IDiv(operand) => {
                 writeln!(file, "    idivl {}", get_operand(operand)).unwrap();
             }
-            assembly::Instruction::BINARY(operator, left, right) => {
+            assembly::Instruction::Binary(operator, left, right) => {
                 let operator = get_binary_operator(operator);
                 let src1 = get_operand(left);
                 let src2 = get_operand(right);
@@ -86,25 +86,25 @@ fn emit_instructions(
                 let reg = get_short_reg(val);
                 writeln!(file, "    set{} {}", code, reg).unwrap();
             }
-            assembly::Instruction::COMPARE(left, right) => {
+            assembly::Instruction::Compare(left, right) => {
                 let left = get_operand(left);
                 let right = get_operand(right);
                 writeln!(file, "    cmpl {}, {}", left, right).unwrap();
             }
-            assembly::Instruction::JMPCond(cond, target) => {
+            assembly::Instruction::JmpCond(cond, target) => {
                 writeln!(file, "    j{} .L_{}", get_cond_code(cond), target).unwrap();
             }
-            assembly::Instruction::JMP(target) => {
+            assembly::Instruction::Jmp(target) => {
                 writeln!(file, "    jmp .L_{}", target).unwrap();
             }
-            assembly::Instruction::LABEL(target) => {
+            assembly::Instruction::Label(target) => {
                 writeln!(file, ".L_{}:", target).unwrap();
             }
-            assembly::Instruction::PUSH(operand) => {
+            assembly::Instruction::Push(operand) => {
                 writeln!(file, "    pushq {}", get_long_reg(operand)).unwrap();
             }
-            assembly::Instruction::CALL(label) => {
-                if let SymbolAttr::FUNCTION(attrs) = &symbols[label].attrs {
+            assembly::Instruction::Call(label) => {
+                if let SymbolAttr::Function(attrs) = &symbols[label].attrs {
                     if attrs.defined {
                         writeln!(file, "    call {}", label).unwrap();
                     } else {
@@ -121,84 +121,84 @@ fn emit_instructions(
 fn get_long_reg(operand: &assembly::Operand) -> String {
     match operand {
         assembly::Operand::IMM(val) => format!("${val}"),
-        assembly::Operand::REGISTER(assembly::Register::AX) => String::from("%rax"),
-        assembly::Operand::REGISTER(assembly::Register::CX) => String::from("%rcx"),
-        assembly::Operand::REGISTER(assembly::Register::DX) => String::from("%rdx"),
-        assembly::Operand::REGISTER(assembly::Register::DI) => String::from("%rdi"),
-        assembly::Operand::REGISTER(assembly::Register::SI) => String::from("%rsi"),
-        assembly::Operand::REGISTER(assembly::Register::R8) => String::from("%r8"),
-        assembly::Operand::REGISTER(assembly::Register::R9) => String::from("%r9"),
-        assembly::Operand::REGISTER(assembly::Register::R10) => String::from("%r10"),
-        assembly::Operand::REGISTER(assembly::Register::R11) => String::from("%r11"),
-        assembly::Operand::REGISTER(assembly::Register::CL) => String::from("%cl"),
-        assembly::Operand::STACK(val) => format!("-{val}(%rbp)"),
-        assembly::Operand::DATA(name) => format!("{name}(%rip)"),
+        assembly::Operand::Register(assembly::Register::AX) => String::from("%rax"),
+        assembly::Operand::Register(assembly::Register::CX) => String::from("%rcx"),
+        assembly::Operand::Register(assembly::Register::DX) => String::from("%rdx"),
+        assembly::Operand::Register(assembly::Register::DI) => String::from("%rdi"),
+        assembly::Operand::Register(assembly::Register::SI) => String::from("%rsi"),
+        assembly::Operand::Register(assembly::Register::R8) => String::from("%r8"),
+        assembly::Operand::Register(assembly::Register::R9) => String::from("%r9"),
+        assembly::Operand::Register(assembly::Register::R10) => String::from("%r10"),
+        assembly::Operand::Register(assembly::Register::R11) => String::from("%r11"),
+        assembly::Operand::Register(assembly::Register::CL) => String::from("%cl"),
+        assembly::Operand::Stack(val) => format!("-{val}(%rbp)"),
+        assembly::Operand::Data(name) => format!("{name}(%rip)"),
     }
 }
 
 fn get_operand(operand: &assembly::Operand) -> String {
     match operand {
         assembly::Operand::IMM(val) => format!("${val}"),
-        assembly::Operand::REGISTER(assembly::Register::AX) => String::from("%eax"),
-        assembly::Operand::REGISTER(assembly::Register::CX) => String::from("%ecx"),
-        assembly::Operand::REGISTER(assembly::Register::DX) => String::from("%edx"),
-        assembly::Operand::REGISTER(assembly::Register::DI) => String::from("%edi"),
-        assembly::Operand::REGISTER(assembly::Register::SI) => String::from("%esi"),
-        assembly::Operand::REGISTER(assembly::Register::R8) => String::from("%r8d"),
-        assembly::Operand::REGISTER(assembly::Register::R9) => String::from("%r9d"),
-        assembly::Operand::REGISTER(assembly::Register::R10) => String::from("%r10d"),
-        assembly::Operand::REGISTER(assembly::Register::R11) => String::from("%r11d"),
-        assembly::Operand::REGISTER(assembly::Register::CL) => String::from("%cl"),
-        assembly::Operand::STACK(val) => format!("-{val}(%rbp)"),
-        assembly::Operand::DATA(name) => format!("{name}(%rip)"),
+        assembly::Operand::Register(assembly::Register::AX) => String::from("%eax"),
+        assembly::Operand::Register(assembly::Register::CX) => String::from("%ecx"),
+        assembly::Operand::Register(assembly::Register::DX) => String::from("%edx"),
+        assembly::Operand::Register(assembly::Register::DI) => String::from("%edi"),
+        assembly::Operand::Register(assembly::Register::SI) => String::from("%esi"),
+        assembly::Operand::Register(assembly::Register::R8) => String::from("%r8d"),
+        assembly::Operand::Register(assembly::Register::R9) => String::from("%r9d"),
+        assembly::Operand::Register(assembly::Register::R10) => String::from("%r10d"),
+        assembly::Operand::Register(assembly::Register::R11) => String::from("%r11d"),
+        assembly::Operand::Register(assembly::Register::CL) => String::from("%cl"),
+        assembly::Operand::Stack(val) => format!("-{val}(%rbp)"),
+        assembly::Operand::Data(name) => format!("{name}(%rip)"),
     }
 }
 
 fn get_short_reg(operand: &assembly::Operand) -> String {
     match operand {
         assembly::Operand::IMM(val) => format!("${val}"),
-        assembly::Operand::REGISTER(assembly::Register::AX) => String::from("%al"),
-        assembly::Operand::REGISTER(assembly::Register::CX) => String::from("%cl"),
-        assembly::Operand::REGISTER(assembly::Register::DX) => String::from("%dl"),
-        assembly::Operand::REGISTER(assembly::Register::DI) => String::from("%dil"),
-        assembly::Operand::REGISTER(assembly::Register::SI) => String::from("%sil"),
-        assembly::Operand::REGISTER(assembly::Register::R8) => String::from("%r8b"),
-        assembly::Operand::REGISTER(assembly::Register::R9) => String::from("%r9b"),
-        assembly::Operand::REGISTER(assembly::Register::R10) => String::from("%r10b"),
-        assembly::Operand::REGISTER(assembly::Register::R11) => String::from("%r11b"),
-        assembly::Operand::REGISTER(assembly::Register::CL) => String::from("%cl"),
-        assembly::Operand::STACK(val) => format!("-{val}(%rbp)"),
-        assembly::Operand::DATA(name) => format!("{name}(%rip)"),
+        assembly::Operand::Register(assembly::Register::AX) => String::from("%al"),
+        assembly::Operand::Register(assembly::Register::CX) => String::from("%cl"),
+        assembly::Operand::Register(assembly::Register::DX) => String::from("%dl"),
+        assembly::Operand::Register(assembly::Register::DI) => String::from("%dil"),
+        assembly::Operand::Register(assembly::Register::SI) => String::from("%sil"),
+        assembly::Operand::Register(assembly::Register::R8) => String::from("%r8b"),
+        assembly::Operand::Register(assembly::Register::R9) => String::from("%r9b"),
+        assembly::Operand::Register(assembly::Register::R10) => String::from("%r10b"),
+        assembly::Operand::Register(assembly::Register::R11) => String::from("%r11b"),
+        assembly::Operand::Register(assembly::Register::CL) => String::from("%cl"),
+        assembly::Operand::Stack(val) => format!("-{val}(%rbp)"),
+        assembly::Operand::Data(name) => format!("{name}(%rip)"),
     }
 }
 
 fn get_cond_code(condition: &assembly::Condition) -> &str {
     match condition {
-        Condition::EQUAL => "e",
-        Condition::NOTEQUAL => "ne",
-        Condition::GREATERTHAN => "g",
-        Condition::GREATERTHANEQUAL => "ge",
-        Condition::LESSTHAN => "l",
-        Condition::LESSTHANEQUAL => "le",
+        Condition::Equal => "e",
+        Condition::NotEqual => "ne",
+        Condition::GreaterThan => "g",
+        Condition::GreaterThanEqual => "ge",
+        Condition::LessThan => "l",
+        Condition::LessThanEqual => "le",
     }
 }
 
 fn get_unary_operator(operator: &assembly::UnaryOperator) -> &str {
     match operator {
-        assembly::UnaryOperator::NEG => "negl",
-        assembly::UnaryOperator::NOT => "notl",
+        assembly::UnaryOperator::Neg => "negl",
+        assembly::UnaryOperator::Not => "notl",
     }
 }
 
 fn get_binary_operator(operator: &assembly::BinaryOperator) -> &str {
     match operator {
-        assembly::BinaryOperator::ADD => "addl",
-        assembly::BinaryOperator::SUB => "subl",
-        assembly::BinaryOperator::MULT => "imull",
-        assembly::BinaryOperator::BITAND => "andl",
-        assembly::BinaryOperator::BITOR => "orl",
-        assembly::BinaryOperator::BITXOR => "xorl",
-        assembly::BinaryOperator::LEFTSHIFT => "sal",
-        assembly::BinaryOperator::RIGHTSHIFT => "sar",
+        assembly::BinaryOperator::Add => "addl",
+        assembly::BinaryOperator::Sub => "subl",
+        assembly::BinaryOperator::Mult => "imull",
+        assembly::BinaryOperator::BitAnd => "andl",
+        assembly::BinaryOperator::BitOr => "orl",
+        assembly::BinaryOperator::BitXor => "xorl",
+        assembly::BinaryOperator::LeftShift => "sal",
+        assembly::BinaryOperator::RightShift => "sar",
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3,69 +3,69 @@ use regex::Regex;
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum TokenType<'a> {
-    SPECIFIER(&'a str),
-    KEYWORD(&'a str),
-    IDENTIFIER(&'a str),
-    CONSTANT(&'a str),
+    Specifier(&'a str),
+    Keyword(&'a str),
+    Identifier(&'a str),
+    Constant(&'a str),
     // Symbols
-    OPENPAREN,
-    CLOSEPAREN,
-    OPENBRACE,
-    CLOSEBRACE,
-    OPENBRACKET,
-    CLOSEBRACKET,
-    SEMICOLON,
+    OpenParen,
+    CloseParen,
+    OpenBrace,
+    CloseBrace,
+    OpenBracket,
+    CloseBracket,
+    SemiColon,
     // Unary Operators
-    TILDE,
-    HYPHEN,
-    DECREMENT,
-    INCREMENT,
+    Tilde,
+    Hyphen,
+    Decrement,
+    Increment,
     // Binary Operators
-    PLUS,
-    STAR,
-    FORWARDSLASH,
-    PERCENT,
-    LEFTSHIFT,
-    RIGHTSHIFT,
-    CARET,
-    PIPE,
-    AMPERSAND,
+    Plus,
+    Star,
+    ForwardSlash,
+    Percent,
+    LeftShift,
+    RightShift,
+    Caret,
+    Pipe,
+    Ampersand,
     // Relational
-    EXCLAM,
-    DOUBLEAMPERSAND,
-    DOUBLEPIPE,
-    DOUBLEEQUAL,
-    NOTEQUAL,
-    LESSTHAN,
-    GREATERTHAN,
-    LESSTHANEQUAL,
-    GREATERTHANEQUAL,
+    Exclam,
+    DoubleAmpersand,
+    DoublePipe,
+    DoubleEqual,
+    ExclamEqual,
+    LessThan,
+    GreaterThan,
+    LessThanEqual,
+    GreaterThanEqual,
     // Assignment
-    EQUAL,
-    PLUSEQUAL,
-    HYPHENEQUAL,
-    STAREQUAL,
-    FORWARDSLASHEQUAL,
-    PERCENTEQUAL,
-    AMPERSANDEQUAL,
-    PIPEEQUAL,
-    CARETEQUAL,
-    LEFTSHIFTEQUAL,
-    RIGHTSHIFTEQUAL,
+    Equal,
+    PlusEqual,
+    HyphenEqual,
+    StarEqual,
+    ForwardSlashEqual,
+    PercentEqual,
+    AmpersandEqual,
+    PipeEqual,
+    CaretEqual,
+    LeftShiftEqual,
+    RightShiftEqual,
     //Conditional,
-    QUESTIONMARK,
-    COLON,
+    QuestionMark,
+    Colon,
     // Other
-    COMMA,
+    Comma,
 }
 
 impl<'a> TokenType<'a> {
     fn from(data: &'a str, token_type: &'a TokenType) -> TokenType<'a> {
         match token_type {
-            TokenType::KEYWORD(_) => TokenType::KEYWORD(data),
-            TokenType::IDENTIFIER(_) => TokenType::IDENTIFIER(data),
-            TokenType::CONSTANT(_) => TokenType::CONSTANT(data),
-            TokenType::SPECIFIER(_) => TokenType::SPECIFIER(data),
+            TokenType::Keyword(_) => TokenType::Keyword(data),
+            TokenType::Identifier(_) => TokenType::Identifier(data),
+            TokenType::Constant(_) => TokenType::Constant(data),
+            TokenType::Specifier(_) => TokenType::Specifier(data),
             _ => token_type.clone(),
         }
     }
@@ -75,12 +75,12 @@ lazy_static! {
     static ref token_regexes: Vec<(TokenType<'static>, Regex)> = {
         let mut regexes: Vec<(TokenType, Regex)> = Vec::new();
         // Keywords
-        regexes.push((TokenType::SPECIFIER(""), Regex::new(&[
+        regexes.push((TokenType::Specifier(""), Regex::new(&[
             r"(^int\b)",
             r"(^static\b)",
             r"(^extern\b)",
         ].join("|")).unwrap()));
-        regexes.push((TokenType::KEYWORD(""), Regex::new(&[
+        regexes.push((TokenType::Keyword(""), Regex::new(&[
             r"(^void\b)",
             r"(^return\b)",
             r"(^if\b)",
@@ -97,60 +97,60 @@ lazy_static! {
         ].join("|")).unwrap()));
         // Identifiers and Constants
         regexes.push((
-            TokenType::IDENTIFIER(""),
+            TokenType::Identifier(""),
             Regex::new(r"^[a-zA-Z_]\w*\b").unwrap(),
         ));
         regexes.push((
-            TokenType::CONSTANT(""),
+            TokenType::Constant(""),
             Regex::new(r"^[0-9]+\b").unwrap(),
         ));
         // 3 Character Symbols
-        regexes.push((TokenType::LEFTSHIFTEQUAL, Regex::new(r"^<<=").unwrap()));
-        regexes.push((TokenType::RIGHTSHIFTEQUAL, Regex::new(r"^>>=").unwrap()));
+        regexes.push((TokenType::LeftShiftEqual, Regex::new(r"^<<=").unwrap()));
+        regexes.push((TokenType::RightShiftEqual, Regex::new(r"^>>=").unwrap()));
         // 2 Character Symbols
-        regexes.push((TokenType::DECREMENT, Regex::new(r"^--").unwrap()));
-        regexes.push((TokenType::INCREMENT, Regex::new(r"^\+\+").unwrap()));
-        regexes.push((TokenType::LEFTSHIFT, Regex::new(r"^<<").unwrap()));
-        regexes.push((TokenType::RIGHTSHIFT, Regex::new(r"^>>").unwrap()));
-        regexes.push((TokenType::DOUBLEAMPERSAND, Regex::new(r"^\&\&").unwrap()));
-        regexes.push((TokenType::DOUBLEEQUAL, Regex::new(r"^==").unwrap()));
-        regexes.push((TokenType::DOUBLEPIPE, Regex::new(r"^\|\|").unwrap()));
-        regexes.push((TokenType::NOTEQUAL, Regex::new(r"^\!=").unwrap()));
-        regexes.push((TokenType::GREATERTHANEQUAL, Regex::new(r"^>=").unwrap()));
-        regexes.push((TokenType::LESSTHANEQUAL, Regex::new(r"^<=").unwrap()));
-        regexes.push((TokenType::PLUSEQUAL, Regex::new(r"^\+\=").unwrap()));
-        regexes.push((TokenType::HYPHENEQUAL, Regex::new(r"^\-\=").unwrap()));
-        regexes.push((TokenType::STAREQUAL, Regex::new(r"^\*\=").unwrap()));
-        regexes.push((TokenType::FORWARDSLASHEQUAL, Regex::new(r"^\/\=").unwrap()));
-        regexes.push((TokenType::PERCENTEQUAL, Regex::new(r"^\%\=").unwrap()));
-        regexes.push((TokenType::AMPERSANDEQUAL, Regex::new(r"^\&\=").unwrap()));
-        regexes.push((TokenType::CARETEQUAL, Regex::new(r"^\^\=").unwrap()));
-        regexes.push((TokenType::PIPEEQUAL, Regex::new(r"^\|\=").unwrap()));
+        regexes.push((TokenType::Decrement, Regex::new(r"^--").unwrap()));
+        regexes.push((TokenType::Increment, Regex::new(r"^\+\+").unwrap()));
+        regexes.push((TokenType::LeftShift, Regex::new(r"^<<").unwrap()));
+        regexes.push((TokenType::RightShift, Regex::new(r"^>>").unwrap()));
+        regexes.push((TokenType::DoubleAmpersand, Regex::new(r"^\&\&").unwrap()));
+        regexes.push((TokenType::DoubleEqual, Regex::new(r"^==").unwrap()));
+        regexes.push((TokenType::DoublePipe, Regex::new(r"^\|\|").unwrap()));
+        regexes.push((TokenType::ExclamEqual, Regex::new(r"^\!=").unwrap()));
+        regexes.push((TokenType::GreaterThanEqual, Regex::new(r"^>=").unwrap()));
+        regexes.push((TokenType::LessThanEqual, Regex::new(r"^<=").unwrap()));
+        regexes.push((TokenType::PlusEqual, Regex::new(r"^\+\=").unwrap()));
+        regexes.push((TokenType::HyphenEqual, Regex::new(r"^\-\=").unwrap()));
+        regexes.push((TokenType::StarEqual, Regex::new(r"^\*\=").unwrap()));
+        regexes.push((TokenType::ForwardSlashEqual, Regex::new(r"^\/\=").unwrap()));
+        regexes.push((TokenType::PercentEqual, Regex::new(r"^\%\=").unwrap()));
+        regexes.push((TokenType::AmpersandEqual, Regex::new(r"^\&\=").unwrap()));
+        regexes.push((TokenType::CaretEqual, Regex::new(r"^\^\=").unwrap()));
+        regexes.push((TokenType::PipeEqual, Regex::new(r"^\|\=").unwrap()));
         // Single Character Symbols
-        regexes.push((TokenType::HYPHEN, Regex::new(r"^-").unwrap()));
-        regexes.push((TokenType::TILDE, Regex::new(r"^~").unwrap()));
-        regexes.push((TokenType::SEMICOLON, Regex::new(r"^;").unwrap()));
-        regexes.push((TokenType::PLUS, Regex::new(r"^\+").unwrap()));
-        regexes.push((TokenType::STAR, Regex::new(r"^\*").unwrap()));
-        regexes.push((TokenType::FORWARDSLASH, Regex::new(r"^\/").unwrap()));
-        regexes.push((TokenType::PERCENT, Regex::new(r"^\%").unwrap()));
-        regexes.push((TokenType::PIPE, Regex::new(r"^\|").unwrap()));
-        regexes.push((TokenType::CARET, Regex::new(r"^\^").unwrap()));
-        regexes.push((TokenType::AMPERSAND, Regex::new(r"^\&").unwrap()));
-        regexes.push((TokenType::EXCLAM, Regex::new(r"^\!").unwrap()));
-        regexes.push((TokenType::GREATERTHAN, Regex::new(r"^>").unwrap()));
-        regexes.push((TokenType::LESSTHAN, Regex::new(r"^<").unwrap()));
-        regexes.push((TokenType::EQUAL, Regex::new(r"^=").unwrap()));
-        regexes.push((TokenType::QUESTIONMARK, Regex::new(r"^\?").unwrap()));
-        regexes.push((TokenType::COLON, Regex::new(r"^\:").unwrap()));
-        regexes.push((TokenType::COMMA, Regex::new(r"^\,").unwrap()));
+        regexes.push((TokenType::Hyphen, Regex::new(r"^-").unwrap()));
+        regexes.push((TokenType::Tilde, Regex::new(r"^~").unwrap()));
+        regexes.push((TokenType::SemiColon, Regex::new(r"^;").unwrap()));
+        regexes.push((TokenType::Plus, Regex::new(r"^\+").unwrap()));
+        regexes.push((TokenType::Star, Regex::new(r"^\*").unwrap()));
+        regexes.push((TokenType::ForwardSlash, Regex::new(r"^\/").unwrap()));
+        regexes.push((TokenType::Percent, Regex::new(r"^\%").unwrap()));
+        regexes.push((TokenType::Pipe, Regex::new(r"^\|").unwrap()));
+        regexes.push((TokenType::Caret, Regex::new(r"^\^").unwrap()));
+        regexes.push((TokenType::Ampersand, Regex::new(r"^\&").unwrap()));
+        regexes.push((TokenType::Exclam, Regex::new(r"^\!").unwrap()));
+        regexes.push((TokenType::GreaterThan, Regex::new(r"^>").unwrap()));
+        regexes.push((TokenType::LessThan, Regex::new(r"^<").unwrap()));
+        regexes.push((TokenType::Equal, Regex::new(r"^=").unwrap()));
+        regexes.push((TokenType::QuestionMark, Regex::new(r"^\?").unwrap()));
+        regexes.push((TokenType::Colon, Regex::new(r"^\:").unwrap()));
+        regexes.push((TokenType::Comma, Regex::new(r"^\,").unwrap()));
         // Brackets
-        regexes.push((TokenType::OPENPAREN, Regex::new(r"^\(").unwrap()));
-        regexes.push((TokenType::CLOSEPAREN, Regex::new(r"^\)").unwrap()));
-        regexes.push((TokenType::OPENBRACE, Regex::new(r"^\{").unwrap()));
-        regexes.push((TokenType::CLOSEBRACE, Regex::new(r"^\}").unwrap()));
-        regexes.push((TokenType::OPENBRACKET, Regex::new(r"^\[").unwrap()));
-        regexes.push((TokenType::CLOSEBRACKET, Regex::new(r"^\]").unwrap()));
+        regexes.push((TokenType::OpenParen, Regex::new(r"^\(").unwrap()));
+        regexes.push((TokenType::CloseParen, Regex::new(r"^\)").unwrap()));
+        regexes.push((TokenType::OpenBrace, Regex::new(r"^\{").unwrap()));
+        regexes.push((TokenType::CloseBrace, Regex::new(r"^\}").unwrap()));
+        regexes.push((TokenType::OpenBracket, Regex::new(r"^\[").unwrap()));
+        regexes.push((TokenType::CloseBracket, Regex::new(r"^\]").unwrap()));
 
         regexes
     };
@@ -163,17 +163,13 @@ pub fn parse<'a>(mut data: &'a str) -> Vec<TokenType<'a>> {
             data = &data[1..];
             continue;
         }
-        let mut success = false;
-        for (token, regex) in token_regexes.iter() {
-            if let Some(found) = regex.find(data) {
-                let result = found.as_str();
-                data = &data[result.len()..];
-                tokens.push(TokenType::from(result, token));
-                success = true;
-                break;
-            }
-        }
-        if !success {
+        if let Some((result, token)) = token_regexes
+            .iter()
+            .find_map(|token_re| token_re.1.find(data).map(|m| (m.as_str(), &token_re.0)))
+        {
+            data = &data[result.len()..];
+            tokens.push(TokenType::from(result, token));
+        } else {
             panic!("Failed to match token '{}'", first_char);
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,26 +12,26 @@ pub type Block = Vec<BlockItem>;
 // Statements and Declarations
 #[derive(Debug)]
 pub enum BlockItem {
-    STATEMENT(Statement),
-    DECLARATION(Declaration),
+    StatementItem(Statement),
+    DeclareItem(Declaration),
 }
 #[derive(Debug)]
 pub enum Statement {
-    RETURN(Expression),
-    EXPRESSION(Expression),
-    IF(Expression, Box<Statement>, Box<Option<Statement>>),
-    WHILE(Loop),
-    DOWHILE(Loop),
-    FOR(ForInit, Loop, Option<Expression>),
-    SWITCH(SwitchStatement),
-    CASE(Expression, Box<Statement>),
-    DEFAULT(Box<Statement>),
-    BREAK(String),
-    CONTINUE(String),
-    COMPOUND(Block),
-    LABEL(String, Box<Statement>),
-    GOTO(String),
-    NULL,
+    Return(Expression),
+    ExprStmt(Expression),
+    If(Expression, Box<Statement>, Box<Option<Statement>>),
+    While(Loop),
+    DoWhile(Loop),
+    For(ForInit, Loop, Option<Expression>),
+    Switch(SwitchStatement),
+    Case(Expression, Box<Statement>),
+    Default(Box<Statement>),
+    Break(String),
+    Continue(String),
+    Compound(Block),
+    Label(String, Box<Statement>),
+    Goto(String),
+    Null,
 }
 #[derive(Debug)]
 pub struct SwitchStatement {
@@ -49,18 +49,18 @@ pub struct Loop {
 }
 #[derive(Debug)]
 pub enum ForInit {
-    INITDECL(VariableDeclaration),
-    INITEXP(Option<Expression>),
+    Decl(VariableDeclaration),
+    Expr(Option<Expression>),
 }
 #[derive(Debug)]
 pub enum Declaration {
-    VARIABLE(VariableDeclaration),
-    FUNCTION(FunctionDeclaration),
+    Variable(VariableDeclaration),
+    Function(FunctionDeclaration),
 }
 #[derive(Debug, PartialEq, Clone)]
 pub enum CType {
-    INT,
-    FUNCTION(usize),
+    Int,
+    Function(usize),
 }
 #[derive(Debug)]
 pub struct VariableDeclaration {
@@ -78,14 +78,14 @@ pub struct FunctionDeclaration {
 }
 #[derive(Debug, PartialEq, Eq)]
 pub enum StorageClass {
-    STATIC,
-    EXTERN,
+    Static,
+    Extern,
 }
 impl StorageClass {
     fn from(token: &TokenType) -> Self {
         match token {
-            TokenType::SPECIFIER("static") => Self::STATIC,
-            TokenType::SPECIFIER("extern") => Self::EXTERN,
+            TokenType::Specifier("static") => Self::Static,
+            TokenType::Specifier("extern") => Self::Extern,
             _ => panic!("Invalid storage class!"),
         }
     }
@@ -93,13 +93,13 @@ impl StorageClass {
 // Expressions
 #[derive(Debug)]
 pub enum Expression {
-    LITEXP(Literal),
-    VAR(String),
-    UNARY(UnaryOperator, Box<Expression>),
-    BINARY(Box<BinaryExpression>),
-    ASSIGNMENT(Box<AssignmentExpression>),
-    CONDITION(Box<ConditionExpression>),
-    FUNCTION(String, Vec<Expression>),
+    LitExpr(Literal),
+    Variable(String),
+    Unary(UnaryOperator, Box<Expression>),
+    Binary(Box<BinaryExpression>),
+    Assignment(Box<AssignmentExpression>),
+    Condition(Box<ConditionExpression>),
+    FunctionCall(String, Vec<Expression>),
 }
 #[derive(Debug)]
 pub struct BinaryExpression {
@@ -122,79 +122,79 @@ pub struct ConditionExpression {
 }
 #[derive(Debug)]
 pub enum UnaryOperator {
-    COMPLEMENT,
-    NEGATE,
-    LOGICALNOT,
-    INCREMENT(Increment),
+    Complement,
+    Negate,
+    LogicalNot,
+    Increment(Increment),
 }
 #[derive(Debug)]
 pub enum Increment {
-    PREINCREMENT,
-    POSTINCREMENT,
-    PREDECREMENT,
-    POSTDECREMENT,
+    PreIncrement,
+    PostIncrement,
+    PreDecrement,
+    PostDecrement,
 }
 #[derive(Debug, Clone)]
 pub enum BinaryOperator {
     // Numeric
-    ADD,
-    SUBTRACT,
-    MULTIPLY,
-    DIVIDE,
-    REMAINDER,
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Remainder,
     // Bitwise
-    LEFTSHIFT,
-    RIGHTSHIFT,
-    BITXOR,
-    BITOR,
-    BITAND,
+    LeftShift,
+    RightShift,
+    BitXor,
+    BitOr,
+    BitAnd,
     // Logical/Relational
-    LOGICALAND,
-    LOGICALOR,
-    ISEQUAL,
-    NOTEQUAL,
-    LESSTHAN,
-    LESSTHANEQUAL,
-    GREATERTHAN,
-    GREATERTHANEQUAL,
+    LogicalAnd,
+    LogicalOr,
+    IsEqual,
+    NotEqual,
+    LessThan,
+    LessThanEqual,
+    GreaterThan,
+    GreaterThanEqual,
 }
 #[derive(Debug, Clone)]
 pub enum Literal {
-    INT(i32),
+    Int(i32),
 }
 
 lazy_static! {
     static ref precedence_table: HashMap<TokenType<'static>, usize> = HashMap::from([
-        (TokenType::STAR, 50),
-        (TokenType::FORWARDSLASH, 50),
-        (TokenType::PERCENT, 50),
-        (TokenType::PLUS, 45),
-        (TokenType::HYPHEN, 45),
-        (TokenType::LEFTSHIFT, 40),
-        (TokenType::RIGHTSHIFT, 40),
-        (TokenType::LESSTHAN, 35),
-        (TokenType::LESSTHANEQUAL, 35),
-        (TokenType::GREATERTHAN, 35),
-        (TokenType::GREATERTHANEQUAL, 35),
-        (TokenType::DOUBLEEQUAL, 30),
-        (TokenType::NOTEQUAL, 30),
-        (TokenType::AMPERSAND, 25),
-        (TokenType::CARET, 20),
-        (TokenType::PIPE, 15),
-        (TokenType::DOUBLEAMPERSAND, 10),
-        (TokenType::DOUBLEPIPE, 5),
-        (TokenType::QUESTIONMARK, 3),
-        (TokenType::EQUAL, 1),
-        (TokenType::PLUSEQUAL, 1),
-        (TokenType::HYPHENEQUAL, 1),
-        (TokenType::STAREQUAL, 1),
-        (TokenType::FORWARDSLASHEQUAL, 1),
-        (TokenType::PERCENTEQUAL, 1),
-        (TokenType::AMPERSANDEQUAL, 1),
-        (TokenType::PIPEEQUAL, 1),
-        (TokenType::CARETEQUAL, 1),
-        (TokenType::LEFTSHIFTEQUAL, 1),
-        (TokenType::RIGHTSHIFTEQUAL, 1),
+        (TokenType::Star, 50),
+        (TokenType::ForwardSlash, 50),
+        (TokenType::Percent, 50),
+        (TokenType::Plus, 45),
+        (TokenType::Hyphen, 45),
+        (TokenType::LeftShift, 40),
+        (TokenType::RightShift, 40),
+        (TokenType::LessThan, 35),
+        (TokenType::LessThanEqual, 35),
+        (TokenType::GreaterThan, 35),
+        (TokenType::GreaterThanEqual, 35),
+        (TokenType::DoubleEqual, 30),
+        (TokenType::ExclamEqual, 30),
+        (TokenType::Ampersand, 25),
+        (TokenType::Caret, 20),
+        (TokenType::Pipe, 15),
+        (TokenType::DoubleAmpersand, 10),
+        (TokenType::DoublePipe, 5),
+        (TokenType::QuestionMark, 3),
+        (TokenType::Equal, 1),
+        (TokenType::PlusEqual, 1),
+        (TokenType::HyphenEqual, 1),
+        (TokenType::StarEqual, 1),
+        (TokenType::ForwardSlashEqual, 1),
+        (TokenType::PercentEqual, 1),
+        (TokenType::AmpersandEqual, 1),
+        (TokenType::PipeEqual, 1),
+        (TokenType::CaretEqual, 1),
+        (TokenType::LeftShiftEqual, 1),
+        (TokenType::RightShiftEqual, 1),
     ]);
 }
 
@@ -225,29 +225,29 @@ fn switch_name() -> String {
 }
 
 fn is_type_specifier(token: &TokenType) -> bool {
-    *token == TokenType::SPECIFIER("int")
+    *token == TokenType::Specifier("int")
 }
 fn is_assignment_token(token: &TokenType) -> bool {
     use TokenType::*;
     matches!(
         token,
-        PLUSEQUAL
-            | HYPHENEQUAL
-            | STAREQUAL
-            | FORWARDSLASHEQUAL
-            | PERCENTEQUAL
-            | AMPERSANDEQUAL
-            | PIPEEQUAL
-            | CARETEQUAL
-            | LEFTSHIFTEQUAL
-            | RIGHTSHIFTEQUAL
+        PlusEqual
+            | HyphenEqual
+            | StarEqual
+            | ForwardSlashEqual
+            | PercentEqual
+            | AmpersandEqual
+            | PipeEqual
+            | CaretEqual
+            | LeftShiftEqual
+            | RightShiftEqual
     )
 }
 
 fn parse_specifiers(tokens: &mut &[TokenType]) -> (CType, Option<StorageClass>) {
     let mut types = Vec::new();
     let mut storage_classes = Vec::new();
-    while matches!(tokens[0], TokenType::SPECIFIER(_)) {
+    while matches!(tokens[0], TokenType::Specifier(_)) {
         if is_type_specifier(&tokens[0]) {
             types.push(&tokens[0]);
         } else {
@@ -261,7 +261,7 @@ fn parse_specifiers(tokens: &mut &[TokenType]) -> (CType, Option<StorageClass>) 
     if storage_classes.len() > 1 {
         panic!("Invalid storage class!")
     }
-    let c_type = CType::INT;
+    let c_type = CType::Int;
     let storage_class = storage_classes.pop();
     (c_type, storage_class)
 }
@@ -271,7 +271,7 @@ fn parse_identifier<'a>(tokens: &mut &[TokenType<'a>]) -> &'a str {
     let next_token = &tokens[0];
     *tokens = &tokens[1..];
     match next_token {
-        TokenType::IDENTIFIER(name) => name,
+        TokenType::Identifier(name) => name,
         _ => panic!("Expected identifier"),
     }
 }
@@ -282,52 +282,52 @@ fn parse_binop(tokens: &mut &[TokenType]) -> BinaryOperator {
     *tokens = &tokens[1..];
     match next_token {
         // Math or Assignment
-        PLUS | PLUSEQUAL => BinaryOperator::ADD,
-        HYPHEN | HYPHENEQUAL => BinaryOperator::SUBTRACT,
-        STAR | STAREQUAL => BinaryOperator::MULTIPLY,
-        FORWARDSLASH | FORWARDSLASHEQUAL => BinaryOperator::DIVIDE,
-        PERCENT | PERCENTEQUAL => BinaryOperator::REMAINDER,
-        LEFTSHIFT | LEFTSHIFTEQUAL => BinaryOperator::LEFTSHIFT,
-        RIGHTSHIFT | RIGHTSHIFTEQUAL => BinaryOperator::RIGHTSHIFT,
-        PIPE | PIPEEQUAL => BinaryOperator::BITOR,
-        CARET | CARETEQUAL => BinaryOperator::BITXOR,
-        AMPERSAND | AMPERSANDEQUAL => BinaryOperator::BITAND,
+        Plus | PlusEqual => BinaryOperator::Add,
+        Hyphen | HyphenEqual => BinaryOperator::Subtract,
+        Star | StarEqual => BinaryOperator::Multiply,
+        ForwardSlash | ForwardSlashEqual => BinaryOperator::Divide,
+        Percent | PercentEqual => BinaryOperator::Remainder,
+        LeftShift | LeftShiftEqual => BinaryOperator::LeftShift,
+        RightShift | RightShiftEqual => BinaryOperator::RightShift,
+        Pipe | PipeEqual => BinaryOperator::BitOr,
+        Caret | CaretEqual => BinaryOperator::BitXor,
+        Ampersand | AmpersandEqual => BinaryOperator::BitAnd,
         // Relational
-        LESSTHAN => BinaryOperator::LESSTHAN,
-        LESSTHANEQUAL => BinaryOperator::LESSTHANEQUAL,
-        GREATERTHAN => BinaryOperator::GREATERTHAN,
-        GREATERTHANEQUAL => BinaryOperator::GREATERTHANEQUAL,
-        DOUBLEEQUAL => BinaryOperator::ISEQUAL,
-        NOTEQUAL => BinaryOperator::NOTEQUAL,
-        DOUBLEAMPERSAND => BinaryOperator::LOGICALAND,
-        DOUBLEPIPE => BinaryOperator::LOGICALOR,
+        LessThan => BinaryOperator::LessThan,
+        LessThanEqual => BinaryOperator::LessThanEqual,
+        GreaterThan => BinaryOperator::GreaterThan,
+        GreaterThanEqual => BinaryOperator::GreaterThanEqual,
+        DoubleEqual => BinaryOperator::IsEqual,
+        ExclamEqual => BinaryOperator::NotEqual,
+        DoubleAmpersand => BinaryOperator::LogicalAnd,
+        DoublePipe => BinaryOperator::LogicalOr,
         _ => panic!("Expected binary operator"),
     }
 }
 fn parse_argument_list(tokens: &mut &[TokenType]) -> Vec<Expression> {
     let mut args: Vec<Expression> = Vec::new();
     let mut comma = false;
-    while tokens[0] != TokenType::CLOSEPAREN {
+    while tokens[0] != TokenType::CloseParen {
         args.push(parse_expression(tokens, 0));
-        comma = try_consume(tokens, TokenType::COMMA);
+        comma = try_consume(tokens, TokenType::Comma);
     }
     assert!(!comma, "Trailing comma not allowed in C arg list");
     args
 }
 fn parse_post_operator(tokens: &mut &[TokenType], expression: Expression) -> Expression {
-    if try_consume(tokens, TokenType::INCREMENT) {
+    if try_consume(tokens, TokenType::Increment) {
         parse_post_operator(
             tokens,
-            Expression::UNARY(
-                UnaryOperator::INCREMENT(Increment::POSTINCREMENT),
+            Expression::Unary(
+                UnaryOperator::Increment(Increment::PostIncrement),
                 expression.into(),
             ),
         )
-    } else if try_consume(tokens, TokenType::DECREMENT) {
+    } else if try_consume(tokens, TokenType::Decrement) {
         parse_post_operator(
             tokens,
-            Expression::UNARY(
-                UnaryOperator::INCREMENT(Increment::POSTDECREMENT),
+            Expression::Unary(
+                UnaryOperator::Increment(Increment::PostDecrement),
                 expression.into(),
             ),
         )
@@ -340,36 +340,36 @@ fn parse_factor(tokens: &mut &[TokenType]) -> Expression {
     let token = &tokens[0];
     *tokens = &tokens[1..];
     match token {
-        TokenType::CONSTANT(val) => Expression::LITEXP(Literal::INT(
+        TokenType::Constant(val) => Expression::LitExpr(Literal::Int(
             val.parse().expect("Failed to convert constant to int"),
         )),
-        TokenType::HYPHEN => Expression::UNARY(UnaryOperator::NEGATE, parse_factor(tokens).into()),
-        TokenType::TILDE => {
-            Expression::UNARY(UnaryOperator::COMPLEMENT, parse_factor(tokens).into())
+        TokenType::Hyphen => Expression::Unary(UnaryOperator::Negate, parse_factor(tokens).into()),
+        TokenType::Tilde => {
+            Expression::Unary(UnaryOperator::Complement, parse_factor(tokens).into())
         }
-        TokenType::EXCLAM => {
-            Expression::UNARY(UnaryOperator::LOGICALNOT, parse_factor(tokens).into())
+        TokenType::Exclam => {
+            Expression::Unary(UnaryOperator::LogicalNot, parse_factor(tokens).into())
         }
-        TokenType::INCREMENT => Expression::UNARY(
-            UnaryOperator::INCREMENT(Increment::PREINCREMENT),
+        TokenType::Increment => Expression::Unary(
+            UnaryOperator::Increment(Increment::PreIncrement),
             parse_factor(tokens).into(),
         ),
-        TokenType::DECREMENT => Expression::UNARY(
-            UnaryOperator::INCREMENT(Increment::PREDECREMENT),
+        TokenType::Decrement => Expression::Unary(
+            UnaryOperator::Increment(Increment::PreDecrement),
             parse_factor(tokens).into(),
         ),
-        TokenType::OPENPAREN => {
+        TokenType::OpenParen => {
             let expr = parse_expression(tokens, 0);
-            expect(tokens, TokenType::CLOSEPAREN);
+            expect(tokens, TokenType::CloseParen);
             parse_post_operator(tokens, expr)
         }
-        TokenType::IDENTIFIER(name) => {
-            if try_consume(tokens, TokenType::OPENPAREN) {
+        TokenType::Identifier(name) => {
+            if try_consume(tokens, TokenType::OpenParen) {
                 let args = parse_argument_list(tokens);
-                expect(tokens, TokenType::CLOSEPAREN);
-                parse_post_operator(tokens, Expression::FUNCTION(name.to_string(), args))
+                expect(tokens, TokenType::CloseParen);
+                parse_post_operator(tokens, Expression::FunctionCall(name.to_string(), args))
             } else {
-                parse_post_operator(tokens, Expression::VAR(name.to_string()))
+                parse_post_operator(tokens, Expression::Variable(name.to_string()))
             }
         }
         _ => panic!("Expected factor, found {:?}", token),
@@ -380,14 +380,14 @@ fn parse_expression(tokens: &mut &[TokenType], min_prec: usize) -> Expression {
     let mut left = parse_factor(tokens);
     while precedence_table.contains_key(&tokens[0]) && precedence_table[&tokens[0]] >= min_prec {
         let token_prec = precedence_table[&tokens[0]];
-        if try_consume(tokens, TokenType::EQUAL) {
+        if try_consume(tokens, TokenType::Equal) {
             let right = parse_expression(tokens, token_prec);
-            left = Expression::ASSIGNMENT(AssignmentExpression { left, right }.into());
-        } else if try_consume(tokens, TokenType::QUESTIONMARK) {
+            left = Expression::Assignment(AssignmentExpression { left, right }.into());
+        } else if try_consume(tokens, TokenType::QuestionMark) {
             let if_true = parse_expression(tokens, 0);
-            expect(tokens, TokenType::COLON);
+            expect(tokens, TokenType::Colon);
             let if_false = parse_expression(tokens, token_prec);
-            left = Expression::CONDITION(
+            left = Expression::Condition(
                 ConditionExpression {
                     condition: left,
                     if_true,
@@ -403,7 +403,7 @@ fn parse_expression(tokens: &mut &[TokenType], min_prec: usize) -> Expression {
             } else {
                 parse_expression(tokens, token_prec + 1)
             };
-            left = Expression::BINARY(
+            left = Expression::Binary(
                 BinaryExpression {
                     operator,
                     left,
@@ -418,84 +418,84 @@ fn parse_expression(tokens: &mut &[TokenType], min_prec: usize) -> Expression {
 }
 fn parse_optional_expression(tokens: &mut &[TokenType]) -> Option<Expression> {
     match tokens[0] {
-        TokenType::CONSTANT(_)
-        | TokenType::HYPHEN
-        | TokenType::TILDE
-        | TokenType::EXCLAM
-        | TokenType::OPENPAREN
-        | TokenType::IDENTIFIER(_) => Some(parse_expression(tokens, 0)),
+        TokenType::Constant(_)
+        | TokenType::Hyphen
+        | TokenType::Tilde
+        | TokenType::Exclam
+        | TokenType::OpenParen
+        | TokenType::Identifier(_) => Some(parse_expression(tokens, 0)),
         _ => None,
     }
 }
 fn parse_statement(tokens: &mut &[TokenType]) -> Statement {
     // Parses a statement
-    if try_consume(tokens, TokenType::KEYWORD("return")) {
+    if try_consume(tokens, TokenType::Keyword("return")) {
         let return_value = parse_expression(tokens, 0);
-        expect(tokens, TokenType::SEMICOLON);
-        Statement::RETURN(return_value)
-    } else if try_consume(tokens, TokenType::SEMICOLON) {
-        Statement::NULL
-    } else if try_consume(tokens, TokenType::KEYWORD("if")) {
-        expect(tokens, TokenType::OPENPAREN);
+        expect(tokens, TokenType::SemiColon);
+        Statement::Return(return_value)
+    } else if try_consume(tokens, TokenType::SemiColon) {
+        Statement::Null
+    } else if try_consume(tokens, TokenType::Keyword("if")) {
+        expect(tokens, TokenType::OpenParen);
         let cond = parse_expression(tokens, 0);
-        expect(tokens, TokenType::CLOSEPAREN);
+        expect(tokens, TokenType::CloseParen);
         let then = parse_statement(tokens);
-        let otherwise = if try_consume(tokens, TokenType::KEYWORD("else")) {
+        let otherwise = if try_consume(tokens, TokenType::Keyword("else")) {
             Some(parse_statement(tokens))
         } else {
             None
         };
-        Statement::IF(cond, then.into(), otherwise.into())
-    } else if try_consume(tokens, TokenType::KEYWORD("goto")) {
+        Statement::If(cond, then.into(), otherwise.into())
+    } else if try_consume(tokens, TokenType::Keyword("goto")) {
         let target = parse_identifier(tokens);
-        expect(tokens, TokenType::SEMICOLON);
-        Statement::GOTO(target.to_string())
-    } else if try_consume(tokens, TokenType::OPENBRACE) {
-        Statement::COMPOUND(parse_block(tokens))
-    } else if try_consume(tokens, TokenType::KEYWORD("break")) {
-        expect(tokens, TokenType::SEMICOLON);
-        Statement::BREAK(String::new())
-    } else if try_consume(tokens, TokenType::KEYWORD("continue")) {
-        expect(tokens, TokenType::SEMICOLON);
-        Statement::CONTINUE(String::new())
-    } else if try_consume(tokens, TokenType::KEYWORD("while")) {
-        expect(tokens, TokenType::OPENPAREN);
+        expect(tokens, TokenType::SemiColon);
+        Statement::Goto(target.to_string())
+    } else if try_consume(tokens, TokenType::OpenBrace) {
+        Statement::Compound(parse_block(tokens))
+    } else if try_consume(tokens, TokenType::Keyword("break")) {
+        expect(tokens, TokenType::SemiColon);
+        Statement::Break(String::new())
+    } else if try_consume(tokens, TokenType::Keyword("continue")) {
+        expect(tokens, TokenType::SemiColon);
+        Statement::Continue(String::new())
+    } else if try_consume(tokens, TokenType::Keyword("while")) {
+        expect(tokens, TokenType::OpenParen);
         let condition = parse_expression(tokens, 0);
-        expect(tokens, TokenType::CLOSEPAREN);
-        Statement::WHILE(Loop {
+        expect(tokens, TokenType::CloseParen);
+        Statement::While(Loop {
             label: loop_name(),
             condition,
             body: parse_statement(tokens).into(),
         })
-    } else if try_consume(tokens, TokenType::KEYWORD("do")) {
+    } else if try_consume(tokens, TokenType::Keyword("do")) {
         let body = parse_statement(tokens);
-        expect(tokens, TokenType::KEYWORD("while"));
-        expect(tokens, TokenType::OPENPAREN);
+        expect(tokens, TokenType::Keyword("while"));
+        expect(tokens, TokenType::OpenParen);
         let condition = parse_expression(tokens, 0);
-        expect(tokens, TokenType::CLOSEPAREN);
-        expect(tokens, TokenType::SEMICOLON);
-        Statement::DOWHILE(Loop {
+        expect(tokens, TokenType::CloseParen);
+        expect(tokens, TokenType::SemiColon);
+        Statement::DoWhile(Loop {
             label: loop_name(),
             condition,
             body: body.into(),
         })
-    } else if try_consume(tokens, TokenType::KEYWORD("for")) {
-        expect(tokens, TokenType::OPENPAREN);
-        let init = if matches!(tokens[0], TokenType::SPECIFIER(_)) {
-            ForInit::INITDECL(parse_variable_declaration(tokens))
+    } else if try_consume(tokens, TokenType::Keyword("for")) {
+        expect(tokens, TokenType::OpenParen);
+        let init = if matches!(tokens[0], TokenType::Specifier(_)) {
+            ForInit::Decl(parse_variable_declaration(tokens))
         } else {
-            let init = ForInit::INITEXP(parse_optional_expression(tokens));
-            expect(tokens, TokenType::SEMICOLON);
+            let init = ForInit::Expr(parse_optional_expression(tokens));
+            expect(tokens, TokenType::SemiColon);
             init
         };
         let condition = match parse_optional_expression(tokens) {
             Some(expr) => expr,
-            None => Expression::LITEXP(Literal::INT(1)),
+            None => Expression::LitExpr(Literal::Int(1)),
         };
-        expect(tokens, TokenType::SEMICOLON);
+        expect(tokens, TokenType::SemiColon);
         let post_loop = parse_optional_expression(tokens);
-        expect(tokens, TokenType::CLOSEPAREN);
-        Statement::FOR(
+        expect(tokens, TokenType::CloseParen);
+        Statement::For(
             init,
             Loop {
                 label: loop_name(),
@@ -504,45 +504,45 @@ fn parse_statement(tokens: &mut &[TokenType]) -> Statement {
             },
             post_loop,
         )
-    } else if try_consume(tokens, TokenType::KEYWORD("switch")) {
+    } else if try_consume(tokens, TokenType::Keyword("switch")) {
         let label = switch_name();
-        expect(tokens, TokenType::OPENPAREN);
+        expect(tokens, TokenType::OpenParen);
         let condition = parse_expression(tokens, 0);
-        expect(tokens, TokenType::CLOSEPAREN);
+        expect(tokens, TokenType::CloseParen);
         let cases = Vec::new();
         let statement = parse_statement(tokens).into();
-        Statement::SWITCH(SwitchStatement {
+        Statement::Switch(SwitchStatement {
             label,
             condition,
             cases,
             statement,
             default: None,
         })
-    } else if try_consume(tokens, TokenType::KEYWORD("default")) {
-        expect(tokens, TokenType::COLON);
-        Statement::DEFAULT(parse_statement(tokens).into())
-    } else if try_consume(tokens, TokenType::KEYWORD("case")) {
+    } else if try_consume(tokens, TokenType::Keyword("default")) {
+        expect(tokens, TokenType::Colon);
+        Statement::Default(parse_statement(tokens).into())
+    } else if try_consume(tokens, TokenType::Keyword("case")) {
         let matcher = parse_expression(tokens, 0);
-        expect(tokens, TokenType::COLON);
+        expect(tokens, TokenType::Colon);
         let statement = parse_statement(tokens).into();
-        Statement::CASE(matcher, statement)
-    } else if matches!(tokens[0], TokenType::IDENTIFIER(_)) && tokens[1] == TokenType::COLON {
-        if let TokenType::IDENTIFIER(name) = tokens[0] {
+        Statement::Case(matcher, statement)
+    } else if matches!(tokens[0], TokenType::Identifier(_)) && tokens[1] == TokenType::Colon {
+        if let TokenType::Identifier(name) = tokens[0] {
             *tokens = &tokens[2..];
-            Statement::LABEL(name.to_string(), parse_statement(tokens).into())
+            Statement::Label(name.to_string(), parse_statement(tokens).into())
         } else {
             panic!("Token 0 must be identifier");
         }
     } else {
         let expr = parse_expression(tokens, 0);
-        expect(tokens, TokenType::SEMICOLON);
-        Statement::EXPRESSION(expr)
+        expect(tokens, TokenType::SemiColon);
+        Statement::ExprStmt(expr)
     }
 }
 fn parse_variable_declaration(tokens: &mut &[TokenType]) -> VariableDeclaration {
     let decl = parse_declaration(tokens);
     match decl {
-        Declaration::VARIABLE(var_decl) => var_decl,
+        Declaration::Variable(var_decl) => var_decl,
         _ => panic!("Expected variable declaration"),
     }
 }
@@ -550,17 +550,17 @@ fn parse_variable_declaration(tokens: &mut &[TokenType]) -> VariableDeclaration 
 fn parse_declaration(tokens: &mut &[TokenType]) -> Declaration {
     let (ctype, storage) = parse_specifiers(tokens);
     let name = parse_identifier(tokens);
-    if try_consume(tokens, TokenType::OPENPAREN) {
+    if try_consume(tokens, TokenType::OpenParen) {
         let params = parse_param_list(tokens);
-        expect(tokens, TokenType::CLOSEPAREN);
-        let body = if try_consume(tokens, TokenType::SEMICOLON) {
+        expect(tokens, TokenType::CloseParen);
+        let body = if try_consume(tokens, TokenType::SemiColon) {
             None
-        } else if try_consume(tokens, TokenType::OPENBRACE) {
+        } else if try_consume(tokens, TokenType::OpenBrace) {
             Some(parse_block(tokens))
         } else {
             panic!("Function declaration must be followed by definition or semicolon");
         };
-        Declaration::FUNCTION(FunctionDeclaration {
+        Declaration::Function(FunctionDeclaration {
             name: name.to_string(),
             params,
             body,
@@ -568,14 +568,14 @@ fn parse_declaration(tokens: &mut &[TokenType]) -> Declaration {
         })
     } else {
         let value = match tokens[0] {
-            TokenType::EQUAL => {
+            TokenType::Equal => {
                 *tokens = &tokens[1..];
                 Some(parse_expression(tokens, 0))
             }
             _ => None,
         };
-        expect(tokens, TokenType::SEMICOLON);
-        Declaration::VARIABLE(VariableDeclaration {
+        expect(tokens, TokenType::SemiColon);
+        Declaration::Variable(VariableDeclaration {
             name: name.to_string(),
             value,
             ctype,
@@ -585,29 +585,29 @@ fn parse_declaration(tokens: &mut &[TokenType]) -> Declaration {
 }
 
 fn parse_block_item(tokens: &mut &[TokenType]) -> BlockItem {
-    if matches!(tokens[0], TokenType::SPECIFIER(_)) {
-        BlockItem::DECLARATION(parse_declaration(tokens))
+    if matches!(tokens[0], TokenType::Specifier(_)) {
+        BlockItem::DeclareItem(parse_declaration(tokens))
     } else {
-        BlockItem::STATEMENT(parse_statement(tokens))
+        BlockItem::StatementItem(parse_statement(tokens))
     }
 }
 fn parse_block(tokens: &mut &[TokenType]) -> Block {
     let mut body: Block = Vec::new();
-    while tokens[0] != TokenType::CLOSEBRACE {
+    while tokens[0] != TokenType::CloseBrace {
         body.push(parse_block_item(tokens));
     }
-    expect(tokens, TokenType::CLOSEBRACE);
+    expect(tokens, TokenType::CloseBrace);
     body
 }
 fn parse_param_list(tokens: &mut &[TokenType]) -> Vec<String> {
-    if try_consume(tokens, TokenType::KEYWORD("void")) {
+    if try_consume(tokens, TokenType::Keyword("void")) {
         return Vec::new();
     }
     let mut params: Vec<String> = Vec::new();
     loop {
-        expect(tokens, TokenType::SPECIFIER("int"));
+        expect(tokens, TokenType::Specifier("int"));
         params.push(parse_identifier(tokens).to_string());
-        if !try_consume(tokens, TokenType::COMMA) {
+        if !try_consume(tokens, TokenType::Comma) {
             break;
         }
     }


### PR DESCRIPTION
Is more in line with rust style guides, and makes the code a little more readable.

Also cleaned up parsing code a bit more.