### PR TITLE
Added full assembly generation for compiling doubles

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 struct_lit_width = 40
+use_small_heuristics = "Max"

--- a/src/codegen/emission.rs
+++ b/src/codegen/emission.rs
@@ -1,5 +1,7 @@
-use super::assembly_gen::{self, AsmSymbol, AssemblyType, BackendSymbols, Condition, StaticVar};
-use crate::validate::type_check::Initializer;
+use super::assembly_gen::{
+    self, AsmSymbol, AssemblyType, BackendSymbols, Condition, StaticConstant, StaticVar,
+};
+use crate::{codegen::assembly_gen::BinaryOperator, validate::type_check::Initializer};
 use std::{fs::File, io::Write};
 
 pub fn emit_program(output_filename: &str, program: assembly_gen::Program) {
@@ -10,10 +12,12 @@ pub fn emit_program(output_filename: &str, program: assembly_gen::Program) {
                 emit_function(&mut file, function, &program.backend_symbols);
             }
             assembly_gen::TopLevelDecl::STATICVAR(var) => emit_static_var(&mut file, var),
+            assembly_gen::TopLevelDecl::STATICCONSTANT(var) => emit_static_const(&mut file, var),
         }
     }
     writeln!(file, "    .section .note.GNU-stack,\"\",@progbits").unwrap();
 }
+
 fn emit_static_var(file: &mut File, var: StaticVar) {
     use Initializer::*;
     if var.global {
@@ -24,9 +28,9 @@ fn emit_static_var(file: &mut File, var: StaticVar) {
         Long(0) | UnsignedLong(0) => String::from(".zero 8"),
         Int(_) | UnsignedInt(_) => format!(".long {}", var.init.int_value()),
         Long(_) | UnsignedLong(_) => format!(".quad {}", var.init.int_value()),
-        Double(_) => panic!("Not implemented!"),
+        Double(val) => format!(".double {}", val),
     };
-    if var.init.int_value() == 0 {
+    if !matches!(var.init, Initializer::Double(_)) && var.init.int_value() == 0 {
         writeln!(file, "    .bss").unwrap();
     } else {
         writeln!(file, "    .data").unwrap();
@@ -35,6 +39,19 @@ fn emit_static_var(file: &mut File, var: StaticVar) {
     writeln!(file, "{}:", var.name).unwrap();
     writeln!(file, "    {}", init).unwrap();
 }
+
+fn emit_static_const(file: &mut File, var: StaticConstant) {
+    writeln!(file, "    .section .rodata").unwrap();
+    writeln!(file, "    .align {}", var.alignment).unwrap();
+    writeln!(file, "{}:", var.name).unwrap();
+    match var.init {
+        Initializer::Double(val) => {
+            writeln!(file, "    .double {val}").unwrap();
+        }
+        _ => panic!("Not a double"),
+    }
+}
+
 fn emit_function(file: &mut File, function: assembly_gen::Function, symbols: &BackendSymbols) {
     if function.global {
         writeln!(file, "    .globl {}", function.name).unwrap()
@@ -77,6 +94,7 @@ fn emit_instructions(
             assembly_gen::Instruction::Cdq(asm_type) => match asm_type {
                 AssemblyType::Longword => writeln!(file, "    cdq").unwrap(),
                 AssemblyType::Quadword => writeln!(file, "    cqo").unwrap(),
+                AssemblyType::Double => panic!("Cdq not supported for double!"),
             },
             assembly_gen::Instruction::IDiv(operand, asm_type) => {
                 let t = get_size_suffix(asm_type);
@@ -89,11 +107,18 @@ fn emit_instructions(
                 writeln!(file, "    div{t} {operand}").unwrap();
             }
             assembly_gen::Instruction::Binary(operator, left, right, asm_type) => {
-                let operator = get_binary_operator(operator);
                 let src = get_operand(left, asm_type);
                 let dst = get_operand(right, asm_type);
-                let t = get_size_suffix(asm_type);
-                writeln!(file, "    {operator}{t} {src}, {dst}").unwrap();
+                // Xor and Mult have special impls for double
+                if *asm_type == AssemblyType::Double && *operator == BinaryOperator::BitXor {
+                    writeln!(file, "    xorpd {src}, {dst}").unwrap();
+                } else if *asm_type == AssemblyType::Double && *operator == BinaryOperator::Mult {
+                    writeln!(file, "    mulsd {src}, {dst}").unwrap();
+                } else {
+                    let operator = get_binary_operator(operator);
+                    let t = get_size_suffix(asm_type);
+                    writeln!(file, "    {operator}{t} {src}, {dst}").unwrap();
+                }
             }
             assembly_gen::Instruction::SetCond(cond, val) => {
                 let code = get_cond_code(cond);
@@ -104,7 +129,11 @@ fn emit_instructions(
                 let left = get_operand(left, cmp_type);
                 let right = get_operand(right, cmp_type);
                 let t = get_size_suffix(cmp_type);
-                writeln!(file, "    cmp{t} {left}, {right}").unwrap();
+                if *cmp_type == AssemblyType::Double {
+                    writeln!(file, "    comisd {left}, {right}").unwrap();
+                } else {
+                    writeln!(file, "    cmp{t} {left}, {right}").unwrap();
+                }
             }
             assembly_gen::Instruction::JmpCond(cond, target) => {
                 writeln!(file, "    j{} .L_{}", get_cond_code(cond), target).unwrap();
@@ -128,58 +157,85 @@ fn emit_instructions(
             assembly_gen::Instruction::MovZeroExtend(_, _) => {
                 panic!("Should be replaced with Mov instructions by rewriter!")
             }
+            assembly_gen::Instruction::Cvttsd2si(src, dst, asm_type) => {
+                let src = get_operand(src, asm_type);
+                let dst = get_operand(dst, asm_type);
+                let t = get_size_suffix(asm_type);
+                writeln!(file, "    cvttsd2si{t} {src}, {dst}").unwrap();
+            }
+            assembly_gen::Instruction::Cvtsi2sd(src, dst, asm_type) => {
+                let src = get_operand(src, asm_type);
+                let dst = get_operand(dst, asm_type);
+                let t = get_size_suffix(asm_type);
+                writeln!(file, "    cvtsi2sd{t} {src}, {dst}").unwrap();
+            }
             assembly_gen::Instruction::NOP => panic!("Noop should just be a placeholder"),
         }
     }
 }
 
 fn get_operand_quadword(operand: &assembly_gen::Operand) -> String {
+    use assembly_gen::Operand::*;
+    use assembly_gen::Register::*;
     match operand {
-        assembly_gen::Operand::IMM(val) => format!("${val}"),
-        assembly_gen::Operand::Register(assembly_gen::Register::AX) => String::from("%rax"),
-        assembly_gen::Operand::Register(assembly_gen::Register::CX) => String::from("%rcx"),
-        assembly_gen::Operand::Register(assembly_gen::Register::DX) => String::from("%rdx"),
-        assembly_gen::Operand::Register(assembly_gen::Register::DI) => String::from("%rdi"),
-        assembly_gen::Operand::Register(assembly_gen::Register::SI) => String::from("%rsi"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R8) => String::from("%r8"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R9) => String::from("%r9"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R10) => String::from("%r10"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R11) => String::from("%r11"),
-        assembly_gen::Operand::Register(assembly_gen::Register::SP) => String::from("%rsp"),
-        assembly_gen::Operand::Register(assembly_gen::Register::CL) => String::from("%cl"),
-        assembly_gen::Operand::Stack(val) => format!("-{val}(%rbp)"),
-        assembly_gen::Operand::Data(name) => format!("{name}(%rip)"),
+        Register(AX) => String::from("%rax"),
+        Register(CX) => String::from("%rcx"),
+        Register(DX) => String::from("%rdx"),
+        Register(DI) => String::from("%rdi"),
+        Register(SI) => String::from("%rsi"),
+        Register(R8) => String::from("%r8"),
+        Register(R9) => String::from("%r9"),
+        Register(R10) => String::from("%r10"),
+        Register(R11) => String::from("%r11"),
+        Register(SP) => String::from("%rsp"),
+        Register(CL) => String::from("%cl"),
+        _ => get_operand_longword(operand),
     }
 }
 fn get_operand_longword(operand: &assembly_gen::Operand) -> String {
+    use assembly_gen::Operand::*;
+    use assembly_gen::Register::*;
     match operand {
-        assembly_gen::Operand::IMM(val) => format!("${val}"),
-        assembly_gen::Operand::Register(assembly_gen::Register::AX) => String::from("%eax"),
-        assembly_gen::Operand::Register(assembly_gen::Register::CX) => String::from("%ecx"),
-        assembly_gen::Operand::Register(assembly_gen::Register::DX) => String::from("%edx"),
-        assembly_gen::Operand::Register(assembly_gen::Register::DI) => String::from("%edi"),
-        assembly_gen::Operand::Register(assembly_gen::Register::SI) => String::from("%esi"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R8) => String::from("%r8d"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R9) => String::from("%r9d"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R10) => String::from("%r10d"),
-        assembly_gen::Operand::Register(assembly_gen::Register::R11) => String::from("%r11d"),
-        assembly_gen::Operand::Register(assembly_gen::Register::CL) => String::from("%cl"),
-        assembly_gen::Operand::Register(assembly_gen::Register::SP) => String::from("%rsp"),
-        assembly_gen::Operand::Stack(val) => format!("-{val}(%rbp)"),
-        assembly_gen::Operand::Data(name) => format!("{name}(%rip)"),
+        IMM(val) => format!("${val}"),
+        // x86 int registers
+        Register(AX) => String::from("%eax"),
+        Register(CX) => String::from("%ecx"),
+        Register(DX) => String::from("%edx"),
+        Register(DI) => String::from("%edi"),
+        Register(SI) => String::from("%esi"),
+        Register(R8) => String::from("%r8d"),
+        Register(R9) => String::from("%r9d"),
+        Register(R10) => String::from("%r10d"),
+        Register(R11) => String::from("%r11d"),
+        //Double Registers
+        Register(XMM0) => String::from("%xmm0"),
+        Register(XMM1) => String::from("%xmm1"),
+        Register(XMM2) => String::from("%xmm2"),
+        Register(XMM3) => String::from("%xmm3"),
+        Register(XMM4) => String::from("%xmm4"),
+        Register(XMM5) => String::from("%xmm5"),
+        Register(XMM6) => String::from("%xmm6"),
+        Register(XMM7) => String::from("%xmm7"),
+        Register(XMM14) => String::from("%xmm14"),
+        Register(XMM15) => String::from("%xmm15"),
+        // Short reg for shifts
+        Register(CL) => String::from("%cl"),
+        //Stack Pointer
+        Register(SP) => String::from("%rsp"),
+        Stack(val) => format!("-{val}(%rbp)"),
+        Data(name) => format!("{name}(%rip)"),
     }
 }
 
 fn get_operand(operand: &assembly_gen::Operand, asm_type: &AssemblyType) -> String {
     match asm_type {
         AssemblyType::Longword => get_operand_longword(operand),
-        AssemblyType::Quadword => get_operand_quadword(operand),
+        AssemblyType::Quadword | AssemblyType::Double => get_operand_quadword(operand),
     }
 }
 
 fn get_short_reg(operand: &assembly_gen::Operand) -> String {
     match operand {
-        assembly_gen::Operand::IMM(val) => format!("${val}"),
         assembly_gen::Operand::Register(assembly_gen::Register::AX) => String::from("%al"),
         assembly_gen::Operand::Register(assembly_gen::Register::CX) => String::from("%cl"),
         assembly_gen::Operand::Register(assembly_gen::Register::DX) => String::from("%dl"),
@@ -191,8 +247,7 @@ fn get_short_reg(operand: &assembly_gen::Operand) -> String {
         assembly_gen::Operand::Register(assembly_gen::Register::R11) => String::from("%r11b"),
         assembly_gen::Operand::Register(assembly_gen::Register::CL) => String::from("%cl"),
         assembly_gen::Operand::Register(assembly_gen::Register::SP) => String::from("%rsp"),
-        assembly_gen::Operand::Stack(val) => format!("-{val}(%rbp)"),
-        assembly_gen::Operand::Data(name) => format!("{name}(%rip)"),
+        _ => get_operand_longword(operand),
     }
 }
 
@@ -215,6 +270,7 @@ fn get_unary_operator(operator: &assembly_gen::UnaryOperator) -> &str {
     match operator {
         assembly_gen::UnaryOperator::Neg => "neg",
         assembly_gen::UnaryOperator::Not => "not",
+        assembly_gen::UnaryOperator::Shr => "shr",
     }
 }
 
@@ -223,6 +279,7 @@ fn get_binary_operator(operator: &assembly_gen::BinaryOperator) -> &str {
         assembly_gen::BinaryOperator::Add => "add",
         assembly_gen::BinaryOperator::Sub => "sub",
         assembly_gen::BinaryOperator::Mult => "imul",
+        assembly_gen::BinaryOperator::DoubleDiv => "div",
         assembly_gen::BinaryOperator::BitAnd => "and",
         assembly_gen::BinaryOperator::BitOr => "or",
         assembly_gen::BinaryOperator::BitXor => "xor",
@@ -237,5 +294,6 @@ fn get_size_suffix(asm_type: &AssemblyType) -> &str {
     match asm_type {
         AssemblyType::Longword => "l",
         AssemblyType::Quadword => "q",
+        AssemblyType::Double => "sd",
     }
 }

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -196,15 +196,10 @@ pub fn parse<'a>(mut data: &'a str) -> Vec<TokenType<'a>> {
             .find_map(|token_re| token_re.1.captures(data).map(|m| (m, &token_re.0)))
         {
             // Use the first capture group instead of 0 so we can exclude characters (fake lookahead). Defaults to 0 if no match
-            let fullmatch = captures
-                .get(1)
-                .map(|m| m.as_str())
-                .unwrap_or(captures.get(0).unwrap().as_str());
+            let fullmatch =
+                captures.get(1).map(|m| m.as_str()).unwrap_or(captures.get(0).unwrap().as_str());
             // Use val capture group to capture data, defaults to full match if it doesn't exist
-            let datamatch = captures
-                .name("val")
-                .map(|m| m.as_str())
-                .unwrap_or(fullmatch);
+            let datamatch = captures.name("val").map(|m| m.as_str()).unwrap_or(fullmatch);
             // Consume data and push token
             data = &data[fullmatch.len()..];
             tokens.push(TokenType::from(datamatch, token));

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -65,10 +65,7 @@ fn try_consume(tokens: &mut &[TokenType], token: TokenType) -> bool {
 }
 fn expect(tokens: &mut &[TokenType], token: TokenType) {
     if token != tokens[0] {
-        panic!(
-            "Syntax Error: Expected `{:?}`, found `{:?}`",
-            token, tokens[0]
-        )
+        panic!("Syntax Error: Expected `{:?}`, found `{:?}`", token, tokens[0])
     }
     *tokens = &tokens[1..];
 }
@@ -152,10 +149,7 @@ fn parse_specifiers(tokens: &mut &[TokenType]) -> (CType, Option<StorageClass>) 
         }
         *tokens = &tokens[1..];
     }
-    assert!(
-        storage_classes.len() <= 1,
-        "Can only have one storage class!"
-    );
+    assert!(storage_classes.len() <= 1, "Can only have one storage class!");
     (parse_type(&mut &types[..]), storage_classes.pop())
 }
 
@@ -246,14 +240,12 @@ fn parse_factor(tokens: &mut &[TokenType]) -> TypedExpression {
         TokenType::Unsigned(val) => match val.parse::<u32>() {
             Ok(val) => Expression::Constant(Constant::UnsignedInt(val.into())).into(),
             Err(_) => Expression::Constant(Constant::UnsignedLong(
-                val.parse()
-                    .expect("Failed to convert unsigned constant to int"),
+                val.parse().expect("Failed to convert unsigned constant to int"),
             ))
             .into(),
         },
         TokenType::UnsignedLong(val) => Expression::Constant(Constant::UnsignedLong(
-            val.parse()
-                .expect("Failed to convert unsigned constant to long"),
+            val.parse().expect("Failed to convert unsigned constant to long"),
         ))
         .into(),
         TokenType::Double(val) => Expression::Constant(Constant::Double(
@@ -294,10 +286,7 @@ fn parse_factor(tokens: &mut &[TokenType]) -> TypedExpression {
             if try_consume(tokens, TokenType::OpenParen) {
                 let args = parse_argument_list(tokens);
                 expect(tokens, TokenType::CloseParen);
-                parse_post_operator(
-                    tokens,
-                    Expression::FunctionCall(name.to_string(), args).into(),
-                )
+                parse_post_operator(tokens, Expression::FunctionCall(name.to_string(), args).into())
             } else {
                 parse_post_operator(tokens, Expression::Variable(name.to_string()).into())
             }


### PR DESCRIPTION
Still doesn't have proper support for NaN comparisons, but has support for all conversions, expressions, and operations, as well as parameter passing as function arguments and return statements per the system V ABI.