### PR TITLE
Add clone to most data structures and Copy to trivially copiable ones

### DIFF
--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum TokenType<'a> {
     Specifier(&'a str),
     Keyword(&'a str),
@@ -64,7 +64,7 @@ pub enum TokenType<'a> {
 }
 
 impl<'a> TokenType<'a> {
-    fn from(data: &'a str, token_type: &'a TokenType) -> TokenType<'a> {
+    fn from(data: &'a str, token_type: TokenType<'a>) -> TokenType<'a> {
         match token_type {
             TokenType::Keyword(_) => TokenType::Keyword(data),
             TokenType::Identifier(_) => TokenType::Identifier(data),
@@ -74,7 +74,7 @@ impl<'a> TokenType<'a> {
             TokenType::Unsigned(_) => TokenType::Unsigned(data),
             TokenType::UnsignedLong(_) => TokenType::UnsignedLong(data),
             TokenType::Double(_) => TokenType::Double(data),
-            _ => token_type.clone(),
+            _ => token_type,
         }
     }
 }
@@ -185,7 +185,7 @@ pub fn parse(mut data: &str) -> Vec<TokenType> {
             let datamatch = captures.name("val").map(|m| m.as_str()).unwrap_or(fullmatch);
             // Consume data and push token
             data = &data[fullmatch.len()..];
-            tokens.push(TokenType::from(datamatch, token));
+            tokens.push(TokenType::from(datamatch, *token));
         } else {
             panic!("Failed to match token '{}'", first_char);
         }

--- a/src/parse/parse_tree.rs
+++ b/src/parse/parse_tree.rs
@@ -3,12 +3,12 @@ use super::lexer::TokenType;
 pub type Program = Vec<Declaration>;
 pub type Block = Vec<BlockItem>;
 // Statements and Declarations
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BlockItem {
     StatementItem(Statement),
     DeclareItem(Declaration),
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Statement {
     Return(TypedExpression),
     ExprStmt(TypedExpression),
@@ -26,7 +26,7 @@ pub enum Statement {
     Goto(String),
     Null,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SwitchStatement {
     pub label: String,
     pub condition: TypedExpression,
@@ -34,23 +34,23 @@ pub struct SwitchStatement {
     pub statement: Box<Statement>,
     pub default: Option<String>,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Loop {
     pub label: String,
     pub condition: TypedExpression,
     pub body: Box<Statement>,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ForInit {
     Decl(VariableDeclaration),
     Expr(Option<TypedExpression>),
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Declaration {
     Variable(VariableDeclaration),
     Function(FunctionDeclaration),
 }
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CType {
     Int,
     Long,
@@ -86,14 +86,14 @@ impl CType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VariableDeclaration {
     pub name: String,
     pub value: Option<TypedExpression>,
     pub ctype: CType,
     pub storage: Option<StorageClass>,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FunctionDeclaration {
     pub name: String,
     pub ctype: CType,
@@ -101,7 +101,7 @@ pub struct FunctionDeclaration {
     pub body: Option<Block>,
     pub storage: Option<StorageClass>,
 }
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StorageClass {
     Static,
     Extern,
@@ -116,7 +116,7 @@ impl StorageClass {
     }
 }
 // Expressions
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TypedExpression {
     pub ctype: Option<CType>,
     pub expr: Expression,
@@ -131,7 +131,7 @@ impl From<Expression> for Box<TypedExpression> {
         TypedExpression { ctype: None, expr: value }.into()
     }
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Expression {
     Constant(Constant),
     Variable(String),
@@ -144,41 +144,40 @@ pub enum Expression {
     Dereference(Box<TypedExpression>),
     AddrOf(Box<TypedExpression>),
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BinaryExpression {
     pub operator: BinaryOperator,
     pub left: TypedExpression,
     pub right: TypedExpression,
     pub is_assignment: bool,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AssignmentExpression {
     pub left: TypedExpression,
     pub right: TypedExpression,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 
 pub struct ConditionExpression {
     pub condition: TypedExpression,
     pub if_true: TypedExpression,
     pub if_false: TypedExpression,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnaryOperator {
     Complement,
     Negate,
     LogicalNot,
-    Increment(Increment),
+    Increment(IncrementType),
 }
-#[allow(clippy::enum_variant_names)]
-#[derive(Debug, Clone)]
-pub enum Increment {
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum IncrementType {
     PreIncrement,
     PostIncrement,
     PreDecrement,
     PostDecrement,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BinaryOperator {
     // Numeric
     Add,
@@ -202,7 +201,7 @@ pub enum BinaryOperator {
     GreaterThan,
     GreaterThanEqual,
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Constant {
     Int(i64), // Limited to i32, but we'll store it as i64 for convenient conversions
     Long(i64),

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -16,7 +16,7 @@ use lexer::TokenType;
 use super::parse_tree::{
     AssignmentExpression, BinaryExpression, BinaryOperator, Block, BlockItem, CType,
     ConditionExpression, Constant, Declaration, Expression, ForInit, FunctionDeclaration,
-    Increment, Loop, Program, Statement, StorageClass, SwitchStatement, TypedExpression,
+    IncrementType, Loop, Program, Statement, StorageClass, SwitchStatement, TypedExpression,
     UnaryOperator, VariableDeclaration,
 };
 
@@ -58,7 +58,7 @@ lazy_static! {
 fn consume<'a>(tokens: &mut &[TokenType<'a>]) -> TokenType<'a> {
     let next_token;
     (next_token, *tokens) = tokens.split_first().expect("Unexpected EOF");
-    next_token.clone()
+    *next_token
 }
 
 fn try_consume(tokens: &mut &[TokenType], token: TokenType) -> bool {
@@ -156,7 +156,7 @@ fn parse_specifiers(tokens: &mut &[TokenType]) -> (CType, Option<StorageClass>) 
     let mut storage_classes = Vec::new();
     while matches!(tokens[0], TokenType::Specifier(_)) {
         if is_type_specifier(&tokens[0]) {
-            types.push(tokens[0].clone());
+            types.push(tokens[0]);
         } else {
             storage_classes.push(StorageClass::from(&tokens[0]));
         }
@@ -217,7 +217,7 @@ fn parse_post_operator(tokens: &mut &[TokenType], expression: TypedExpression) -
         parse_post_operator(
             tokens,
             Expression::Unary(
-                UnaryOperator::Increment(Increment::PostIncrement),
+                UnaryOperator::Increment(IncrementType::PostIncrement),
                 expression.into(),
             )
             .into(),
@@ -226,7 +226,7 @@ fn parse_post_operator(tokens: &mut &[TokenType], expression: TypedExpression) -
         parse_post_operator(
             tokens,
             Expression::Unary(
-                UnaryOperator::Increment(Increment::PostDecrement),
+                UnaryOperator::Increment(IncrementType::PostDecrement),
                 expression.into(),
             )
             .into(),
@@ -277,12 +277,12 @@ fn parse_factor(tokens: &mut &[TokenType]) -> TypedExpression {
         TokenType::Ampersand => Expression::AddrOf(parse_factor(tokens).into()).into(),
         TokenType::Star => Expression::Dereference(parse_factor(tokens).into()).into(),
         TokenType::Increment => Expression::Unary(
-            UnaryOperator::Increment(Increment::PreIncrement),
+            UnaryOperator::Increment(IncrementType::PreIncrement),
             parse_factor(tokens).into(),
         )
         .into(),
         TokenType::Decrement => Expression::Unary(
-            UnaryOperator::Increment(Increment::PreDecrement),
+            UnaryOperator::Increment(IncrementType::PreDecrement),
             parse_factor(tokens).into(),
         )
         .into(),

--- a/src/tac_generation/generator.rs
+++ b/src/tac_generation/generator.rs
@@ -8,19 +8,19 @@ use crate::{
 };
 
 pub type Program = Vec<TopLevelDecl>;
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TopLevelDecl {
     Function(Function),
     StaticDecl(StaticVariable),
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Function {
     pub name: String,
     pub params: Vec<Value>,
     pub instructions: Vec<Instruction>,
     pub global: bool,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StaticVariable {
     pub identifier: String,
     pub global: bool,
@@ -28,7 +28,7 @@ pub struct StaticVariable {
     pub ctype: CType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Instruction {
     Return(Value),
     SignExtend(Value, Value),
@@ -46,13 +46,13 @@ pub enum Instruction {
     JumpCond(InstructionJump),
     Function(String, Vec<Value>, Value),
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InstructionUnary {
     pub operator: UnaryOperator,
     pub src: Value,
     pub dst: Value,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum UnaryOperator {
     Complement,
     Negate,
@@ -69,25 +69,25 @@ impl InstructionUnary {
         Self { operator, src, dst }
     }
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InstructionBinary {
     pub operator: BinaryOperator,
     pub src1: Value,
     pub src2: Value,
     pub dst: Value,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InstructionCopy {
     pub src: Value,
     pub dst: Value,
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InstructionJump {
     pub jump_type: JumpType,
     pub condition: Value,
     pub target: String,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum JumpType {
     JumpIfZero,
     JumpIfNotZero,
@@ -110,11 +110,11 @@ pub fn gen_tac_ast(parser_ast: parse_tree::Program, symbols: &mut Symbols) -> Pr
     for (name, entry) in symbols {
         if let SymbolAttr::Static(var_attrs) = &entry.attrs {
             match &var_attrs.init {
-                StaticInitializer::Initialized(initializer) => {
+                &StaticInitializer::Initialized(initializer) => {
                     program.push(TopLevelDecl::StaticDecl(StaticVariable {
                         identifier: name.clone(),
                         global: var_attrs.global,
-                        initializer: initializer.clone(),
+                        initializer,
                         ctype: entry.ctype.clone(),
                     }));
                 }
@@ -330,7 +330,7 @@ fn gen_expression(
             expr,
         ) => {
             use parse_tree::Constant;
-            use parse_tree::Increment::*;
+            use parse_tree::IncrementType::*;
             let is_double = get_type(&expr) == CType::Double;
             let dst = gen_expression(*expr, instructions, symbols);
             let operator = match increment_type {

--- a/src/validate/type_check.rs
+++ b/src/validate/type_check.rs
@@ -9,14 +9,14 @@ use crate::parse::parse_tree::{
     Statement, StorageClass, TypedExpression, UnaryOperator, VariableDeclaration,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct TypeTable {
     symbols: Symbols,
     current_function: Option<String>,
 }
 
 pub type Symbols = HashMap<String, Symbol>;
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Symbol {
     pub ctype: CType,
     pub attrs: SymbolAttr,
@@ -37,30 +37,30 @@ impl Symbol {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum SymbolAttr {
     Function(FunctionAttributes),
     Static(StaticAttributes),
     Local,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FunctionAttributes {
     pub defined: bool,
     pub global: bool,
 }
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StaticAttributes {
     pub init: StaticInitializer,
     pub global: bool,
 }
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum StaticInitializer {
     Tentative,
     Initialized(Initializer),
     None,
 }
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Initializer {
     Int(i64), // Limited to i32, but we store as i64 for matching and do our own conversion
     Long(i64),
@@ -513,7 +513,7 @@ fn type_check_var_filescope(var: &VariableDeclaration, table: &mut TypeTable) {
                 !matches!(init_value, StaticInitializer::Initialized(_)),
                 "Conflicting static initializers!"
             );
-            init_value = attrs.init.clone();
+            init_value = attrs.init;
         } else if attrs.init == StaticInitializer::Tentative
             && !matches!(init_value, StaticInitializer::Initialized(_))
         {


### PR DESCRIPTION
Also remove unnecessary clones, remove lvalue check from semantics as it belongs in the type checker.

Mainly just a code cleanup commit preparing to implement type checking for pointers now that we can parse them correctly.