### PR TITLE
Replace stack operand with memory offset to register

### DIFF
--- a/src/codegen/assembly_rewrite.rs
+++ b/src/codegen/assembly_rewrite.rs
@@ -192,7 +192,7 @@ fn rewrite_arithmetic_binary(instructions: &mut Vec<Instruction>, bin_op: Instru
         src = Reg(R10);
     }
     // Rewrite dst (currently only if mult tries to put result in memory)
-    if operator == BinaryOperator::Mult && matches!(dst, Operand::Data(_) | Operand::Stack(_)) {
+    if operator == BinaryOperator::Mult && is_mem_operand(&dst) {
         instructions.push(Instruction::Mov(dst.clone(), Reg(R11), op_type));
         instructions.push(Instruction::Binary(operator, src, Reg(R11), op_type));
         instructions.push(Instruction::Mov(Reg(R11), dst, op_type));
@@ -222,5 +222,5 @@ pub fn check_overflow(operand: &Operand, max_size: i128) -> bool {
 }
 
 pub fn is_mem_operand(operand: &Operand) -> bool {
-    matches!(operand, Operand::Data(_) | Operand::Stack(_))
+    matches!(operand, Operand::Data(_) | Operand::Memory(_, _))
 }

--- a/src/codegen/emission.rs
+++ b/src/codegen/emission.rs
@@ -188,6 +188,7 @@ fn get_operand_quadword(operand: &assembly_gen::Operand) -> String {
         Register(R10) => String::from("%r10"),
         Register(R11) => String::from("%r11"),
         Register(SP) => String::from("%rsp"),
+        Register(BP) => String::from("%rbp"),
         Register(CL) => String::from("%cl"),
         _ => get_operand_longword(operand),
     }
@@ -207,6 +208,8 @@ fn get_operand_longword(operand: &assembly_gen::Operand) -> String {
         Register(R9) => String::from("%r9d"),
         Register(R10) => String::from("%r10d"),
         Register(R11) => String::from("%r11d"),
+        Register(SP) => String::from("%esp"),
+        Register(BP) => String::from("%ebp"),
         //Double Registers
         Register(XMM0) => String::from("%xmm0"),
         Register(XMM1) => String::from("%xmm1"),
@@ -220,9 +223,10 @@ fn get_operand_longword(operand: &assembly_gen::Operand) -> String {
         Register(XMM15) => String::from("%xmm15"),
         // Short reg for shifts
         Register(CL) => String::from("%cl"),
-        //Stack Pointer
-        Register(SP) => String::from("%rsp"),
-        Stack(val) => format!("-{val}(%rbp)"),
+        Memory(reg, val) => {
+            let reg = get_operand_quadword(&Register(*reg));
+            format!("{val}({reg})")
+        }
         Data(name) => format!("{name}(%rip)"),
     }
 }


### PR DESCRIPTION
Last step before adding final pointer assembly gen, we can now specify relative offsets to memory.