### PR TITLE
Rewrite compound assignment to fix double lval evaluation

### DIFF
--- a/src/validate/semantics.rs
+++ b/src/validate/semantics.rs
@@ -1,6 +1,6 @@
 use crate::parse::parse_tree::{
-    self, AssignmentExpression, BlockItem, Declaration, ForInit, FunctionDeclaration, Loop,
-    Program, Statement, StorageClass, SwitchStatement, TypedExpression, VariableDeclaration,
+    self, BlockItem, Declaration, ForInit, FunctionDeclaration, Loop, Program, Statement,
+    StorageClass, SwitchStatement, TypedExpression, VariableDeclaration,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -354,18 +354,7 @@ fn resolve_expression(expr: TypedExpression, symbols: &mut SymbolTable) -> Typed
         Binary(mut binexpr) => {
             binexpr.left = resolve_expression(binexpr.left, symbols);
             binexpr.right = resolve_expression(binexpr.right, symbols);
-            if binexpr.is_assignment {
-                Assignment(
-                    AssignmentExpression {
-                        left: binexpr.left.clone(),
-                        right: Binary(binexpr).into(),
-                    }
-                    .into(),
-                )
-                .into()
-            } else {
-                Binary(binexpr).into()
-            }
+            Binary(binexpr).into()
         }
         Condition(mut cond) => {
             cond.condition = resolve_expression(cond.condition, symbols);

--- a/src/validate/type_check.rs
+++ b/src/validate/type_check.rs
@@ -350,7 +350,7 @@ fn type_check_expression(expr: TypedExpression, table: &mut TypeTable) -> TypedE
             let common_type = if left_t.is_pointer() || right_t.is_pointer() {
                 get_common_pointer_type(&left, &right)
             } else {
-                get_common_type(left_t, right_t)
+                get_common_type(left_t.clone(), right_t)
             };
             // Generate type for expression
             let ctype = match binary.operator {
@@ -376,6 +376,13 @@ fn type_check_expression(expr: TypedExpression, table: &mut TypeTable) -> TypedE
                 }
                 _ => CType::Int,
             };
+            // Type check assignment
+            if binary.is_assignment {
+                assert!(left.is_lvalue(), "Can only assign to lvalue!");
+                let right = convert_to(right, &ctype);
+                let binexpr = BinaryExpression { left, right, ..*binary };
+                return set_type(Binary(binexpr.into()).into(), &ctype);
+            }
             // Generate necessary casts
             let expr = match binary.operator {
                 LeftShift | RightShift => BinaryExpression { left, right, ..*binary },


### PR DESCRIPTION
We can't just use the naive approach of converting compound assignments like `a += b` into `a = a + b` because this risks evaluating the lvalue twice.

In basic cases this seems irrelevant, but in C it is legal to write the following code:

`long* func(void) {...}

*func() += 5;
`

If we use the naive approach, func would be called twice.

----

Therefore, this diff rewrites compound assignment just using the binary operator element from our AST. To get the type checking right, we convert the right hand side to the common type in the type checker, but delay creating casts for the left hand side until the generator.

Then we need to cast the lval to the common type for the operation, and the result back to the lval type before assigning it, all while only evaluating the lval once.