### PR TITLE
Subscript expression parsing for arrays

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -231,6 +231,13 @@ fn parse_post_operator(tokens: &mut &[TokenType], expression: TypedExpression) -
             )
             .into(),
         )
+    } else if try_consume(tokens, TokenType::OpenBracket) {
+        let sub_expr = parse_expression(tokens, 0);
+        expect(tokens, TokenType::CloseBracket);
+        parse_post_operator(
+            tokens,
+            Expression::Subscript(expression.into(), sub_expr.into()).into(),
+        )
     } else {
         expression
     }


### PR DESCRIPTION
Parse subscript expressions for arrays.

Note we still don't parse array declarations (including declarators or abstract declarators), so we can't declare arrays yet in the parser.

Tests:
Verified that the correct tree was built with the right order of operations for expressions such as x++[5] and x[5]++.