### PR TITLE
Added parsing for array declarators (and abstract declarators)

### DIFF
--- a/src/parse/parse_tree.rs
+++ b/src/parse/parse_tree.rs
@@ -80,11 +80,11 @@ pub enum CType {
     Double,
     Function(Vec<CType>, Box<CType>),
     Pointer(Box<CType>),
-    Array(Box<CType>, usize),
+    Array(Box<CType>, u64),
 }
 
 impl CType {
-    pub fn size(&self) -> usize {
+    pub fn size(&self) -> u64 {
         match self {
             CType::Int | CType::UnsignedInt => 4,
             CType::Long | CType::UnsignedLong => 8,
@@ -255,5 +255,8 @@ impl Constant {
             Self::UnsignedInt(val) | Self::UnsignedLong(val) => *val as i128,
             Self::Double(val) => *val as i128,
         }
+    }
+    pub fn is_integer(&self) -> bool {
+        matches!(self, Self::Int(_) | Self::Long(_) | Self::UnsignedInt(_) | Self::UnsignedLong(_))
     }
 }

--- a/src/parse/parser/declarators.rs
+++ b/src/parse/parser/declarators.rs
@@ -1,12 +1,13 @@
 use crate::parse::{lexer::TokenType, parse_tree::CType};
 
-use super::{expect, parse_identifier, parse_type, try_consume};
+use super::{consume, expect, parse_constant, parse_identifier, parse_type, try_consume};
 
 #[derive(Debug)]
 pub enum Declarator {
     Identifier(String),
     Pointer(Box<Declarator>),
     Function(Vec<ParamInfo>, Box<Declarator>),
+    Array(Box<Declarator>, u64),
 }
 #[derive(Debug)]
 pub struct ParamInfo {
@@ -26,7 +27,9 @@ fn parse_simple_declarator(tokens: &mut &[TokenType]) -> Declarator {
 
 fn parse_direct_declarator(tokens: &mut &[TokenType]) -> Declarator {
     let declarator = parse_simple_declarator(tokens);
-    if try_consume(tokens, TokenType::OpenParen) {
+    if tokens[0] == TokenType::OpenBracket {
+        parse_array_declarator(tokens, declarator)
+    } else if try_consume(tokens, TokenType::OpenParen) {
         let param_info = parse_param_list(tokens)
             .into_iter()
             .map(|(ctype, declarator)| ParamInfo { ctype, declarator: declarator.into() })
@@ -37,6 +40,19 @@ fn parse_direct_declarator(tokens: &mut &[TokenType]) -> Declarator {
         declarator
     }
 }
+
+fn parse_array_declarator(tokens: &mut &[TokenType], mut declarator: Declarator) -> Declarator {
+    while try_consume(tokens, TokenType::OpenBracket) {
+        let subscript = parse_constant(&consume(tokens));
+        assert!(subscript.is_integer(), "Array indices must be integers");
+        let subscript = subscript.int_value() as u64;
+        assert!(subscript > 0, "Array must have size > 0");
+        declarator = Declarator::Array(declarator.into(), subscript);
+        expect(tokens, TokenType::CloseBracket);
+    }
+    declarator
+}
+
 fn parse_param_list(tokens: &mut &[TokenType]) -> Vec<(CType, Declarator)> {
     if try_consume(tokens, TokenType::Keyword("void")) {
         return Vec::new();
@@ -76,6 +92,10 @@ pub fn process_declarator(decl: Declarator, base_type: CType) -> DeclaratorResul
             params: Vec::new(),
         },
         Declarator::Pointer(inner) => process_declarator(*inner, CType::Pointer(base_type.into())),
+        Declarator::Array(inner, size) => {
+            let derived_t = CType::Array(base_type.into(), size);
+            process_declarator(*inner, derived_t)
+        }
         Declarator::Function(params, inner) => match *inner {
             Declarator::Identifier(name) => {
                 let mut param_types = Vec::new();
@@ -102,32 +122,62 @@ pub fn process_declarator(decl: Declarator, base_type: CType) -> DeclaratorResul
 
 #[derive(Debug)]
 pub enum AbstractDeclarator {
-    Pointer(Box<AbstractDeclarator>),
     Base,
+    Pointer(Box<AbstractDeclarator>),
+    Array(Box<AbstractDeclarator>, u64),
+}
+
+pub fn parse_simple_abstract_declarator(tokens: &mut &[TokenType]) -> AbstractDeclarator {
+    if try_consume(tokens, TokenType::OpenParen) {
+        let declarator = parse_abstract_declarator(tokens);
+        expect(tokens, TokenType::CloseParen);
+        declarator
+    } else {
+        AbstractDeclarator::Base
+    }
+}
+
+fn parse_direct_abstract_declarator(tokens: &mut &[TokenType]) -> AbstractDeclarator {
+    let declarator = parse_simple_abstract_declarator(tokens);
+    if tokens[0] == TokenType::OpenBracket {
+        parse_abstract_array_declarator(tokens, declarator)
+    } else {
+        declarator
+    }
 }
 
 pub fn parse_abstract_declarator(tokens: &mut &[TokenType]) -> AbstractDeclarator {
     if try_consume(tokens, TokenType::Star) {
         AbstractDeclarator::Pointer(parse_abstract_declarator(tokens).into())
-    } else if try_consume(tokens, TokenType::CloseParen) {
-        AbstractDeclarator::Base
     } else {
         parse_direct_abstract_declarator(tokens)
     }
 }
 
-fn parse_direct_abstract_declarator(tokens: &mut &[TokenType]) -> AbstractDeclarator {
-    expect(tokens, TokenType::OpenParen);
-    let result = parse_abstract_declarator(tokens);
-    expect(tokens, TokenType::CloseParen);
-    result
+fn parse_abstract_array_declarator(
+    tokens: &mut &[TokenType],
+    mut decl: AbstractDeclarator,
+) -> AbstractDeclarator {
+    while try_consume(tokens, TokenType::OpenBracket) {
+        let subscript = parse_constant(&consume(tokens));
+        assert!(subscript.is_integer(), "Array indices must be integers");
+        let subscript = subscript.int_value() as u64;
+        assert!(subscript > 0, "Array must have size > 0");
+        decl = AbstractDeclarator::Array(decl.into(), subscript);
+        expect(tokens, TokenType::CloseBracket);
+    }
+    decl
 }
 
 pub fn process_abstract_declarator(decl: AbstractDeclarator, base_type: CType) -> CType {
     match decl {
         AbstractDeclarator::Base => base_type,
         AbstractDeclarator::Pointer(inner) => {
-            CType::Pointer(process_abstract_declarator(*inner, base_type).into())
+            process_abstract_declarator(*inner, CType::Pointer(base_type.into()))
+        }
+        AbstractDeclarator::Array(inner, size) => {
+            let derived_t = CType::Array(base_type.into(), size);
+            process_abstract_declarator(*inner, derived_t)
         }
     }
 }

--- a/src/validate/semantics.rs
+++ b/src/validate/semantics.rs
@@ -145,7 +145,6 @@ impl SymbolTable {
         let name = &decl.name;
         let stack_len = self.identifiers.len() - 1;
         if let Some(prev_declaration) = self.identifiers[stack_len].get(name) {
-            println!("{:?} and {:?}", prev_declaration.external, decl.storage);
             assert!(
                 prev_declaration.external && decl.storage == Some(StorageClass::Extern),
                 "Duplicate variable name in current scope: {}",

--- a/src/validate/type_check.rs
+++ b/src/validate/type_check.rs
@@ -306,7 +306,6 @@ fn type_check_expression(expr: TypedExpression, table: &mut TypeTable) -> TypedE
         Expression::Cast(new_type, inner) => {
             let typed_inner = type_check_expression(*inner, table);
             let old_type = get_type(&typed_inner);
-            println!("{:#?} {:#?}", old_type, new_type);
             if new_type == CType::Double && old_type.is_pointer()
                 || old_type == CType::Double && new_type.is_pointer()
             {


### PR DESCRIPTION
Still need to add parsing for array initializer lists, but most of the array parsing logic is finished now.

Required a small rewrite of the abstract declarator logic due to some logic errors, although pointer parsing was so simple the logic errors never caused actual program level bugs.

Tests:
Ran writing c book tests, all array parsing failures were due to unexpected braces in initializer lists. Previous tests still succeed so there shouldn't be any regression for non-array logic.