### PR TITLE
Clean up typechecking code for binary operations

### DIFF
--- a/src/parse/parse_tree.rs
+++ b/src/parse/parse_tree.rs
@@ -165,7 +165,10 @@ impl From<Expression> for Box<TypedExpression> {
 }
 impl TypedExpression {
     pub fn is_lvalue(&self) -> bool {
-        matches!(self.expr, Expression::Variable(_) | Expression::Dereference(_))
+        matches!(
+            self.expr,
+            Expression::Variable(_) | Expression::Dereference(_) | Expression::Subscript(_, _)
+        )
     }
 }
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Rewrote the Binary Expression type checking to be more modular with separate handling for different operators. Before it was a mess of logic trying not to repeat itself, but made making updates to handler operators difficult.

This should prepare us to add pointer handling specifically to the Add/Subtract operators (including compound assignment), without affecting other binary operators.

I also added a few misc changes to prepare for type checking arrays
- Added subscript functions as lvalues
- Added type_check_and_convert function that automatically converts array results to pointers (unless used in an addrOf expression).
- Added check to not compare pointers to 0, which isn't valid C outside of some gcc/clang extensions.