### PR TITLE
Add Arrays and Pointer arithmetic (assembly generation and code emission)

### DIFF
--- a/src/codegen/assembly_gen.rs
+++ b/src/codegen/assembly_gen.rs
@@ -1,4 +1,4 @@
-use std::cmp::{self, Ordering};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::iter::zip;
 use std::sync::atomic::AtomicUsize;
@@ -123,7 +123,7 @@ impl AssemblyType {
             CType::Array(elem_t, _) => {
                 let size = ctype.size();
                 let alignment = if size < 16 { elem_t.size() } else { 16 };
-                if ![1,2,4,8,16].contains(&alignment) {
+                if ![1, 2, 4, 8, 16].contains(&alignment) {
                     panic!("Alignment error: {:#?}", alignment)
                 }
                 AssemblyType::ByteArray(size, alignment as usize)

--- a/src/codegen/assembly_gen.rs
+++ b/src/codegen/assembly_gen.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::iter::zip;
 use std::sync::atomic::AtomicUsize;
@@ -104,6 +104,7 @@ pub enum Operand {
     Memory(Register, isize),
     Register(Register),
     Data(String),
+    Indexed(Register, Register, u64),
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssemblyType {
@@ -119,7 +120,15 @@ impl AssemblyType {
             CType::Long | CType::UnsignedLong => AssemblyType::Quadword,
             CType::Double => AssemblyType::Double,
             CType::Pointer(_) => AssemblyType::Quadword,
-            _ => panic!("Expected a variable!"),
+            CType::Array(elem_t, _) => {
+                let size = ctype.size();
+                let alignment = if size < 16 { elem_t.size() } else { 16 };
+                if ![1,2,4,8,16].contains(&alignment) {
+                    panic!("Alignment error: {:#?}", alignment)
+                }
+                AssemblyType::ByteArray(size, alignment as usize)
+            }
+            CType::Function(_, _) => panic!("Not a variable!"),
         }
     }
 }
@@ -249,7 +258,8 @@ pub fn gen_assembly_tree(ast: generator::Program, symbols: Symbols) -> Program {
                 }));
             }
             generator::TopLevelDecl::StaticDecl(static_data) => {
-                let alignment = static_data.ctype.size();
+                // Calculate smaller valid alignment if possible TODO:
+                let alignment = 16;
                 program.push(TopLevelDecl::Var(StaticVar {
                     name: static_data.identifier,
                     global: static_data.global,
@@ -476,6 +486,7 @@ fn gen_instructions(
             }
             generator::Instruction::Load(ptr, dst) => {
                 let dst_type = AssemblyType::from(&get_type(&dst, symbols));
+                assert!(!matches!(dst_type, AssemblyType::ByteArray(_, _)), "LOAD BYTEARRAY!");
                 let ptr = gen_operand(ptr, stack, symbols);
                 let dst = gen_operand(dst, stack, symbols);
                 asm_instructions.push(Mov(ptr, Reg(AX), AssemblyType::Quadword));
@@ -483,13 +494,40 @@ fn gen_instructions(
             }
             generator::Instruction::Store(src, ptr) => {
                 let src_type = AssemblyType::from(&get_type(&src, symbols));
+                assert!(!matches!(src_type, AssemblyType::ByteArray(_, _)), "STORE BYTEARRAY!");
                 let src = gen_operand(src, stack, symbols);
                 let ptr = gen_operand(ptr, stack, symbols);
                 asm_instructions.push(Mov(ptr, Reg(AX), AssemblyType::Quadword));
                 asm_instructions.push(Mov(src, Memory(AX, 0), src_type));
             }
-            generator::Instruction::AddPtr(_, _, _, _) => panic!("Notimplemented"),
-            generator::Instruction::CopyToOffset(_, _, _) => panic!("Not implemented!"),
+            generator::Instruction::AddPtr(ptr, index, scale, dst) => {
+                let ptr = gen_operand(ptr, stack, symbols);
+                let index = gen_operand(index, stack, symbols);
+                let dst = gen_operand(dst, stack, symbols);
+                asm_instructions.push(Mov(ptr, Reg(AX), AssemblyType::Quadword));
+                if let Imm(index_val) = index {
+                    let offset = index_val as isize * scale as isize;
+                    asm_instructions.push(Lea(Memory(AX, offset), dst));
+                } else if [1, 2, 4, 8].contains(&scale) {
+                    asm_instructions.push(Mov(index, Reg(DX), AssemblyType::Quadword));
+                    asm_instructions.push(Lea(Operand::Indexed(AX, DX, scale), dst));
+                } else {
+                    asm_instructions.push(Mov(index, Reg(DX), AssemblyType::Quadword));
+                    asm_instructions.push(Binary(
+                        BinaryOperator::Mult,
+                        Imm(scale.into()),
+                        Reg(DX),
+                        AssemblyType::Quadword,
+                    ));
+                    asm_instructions.push(Lea(Operand::Indexed(AX, DX, 1), dst));
+                }
+            }
+            generator::Instruction::CopyToOffset(src, dst, offset) => {
+                let src_type = AssemblyType::from(&get_type(&src, symbols));
+                let src = gen_operand(src, stack, symbols);
+                let dst = gen_mem_offset(dst, offset as isize, stack, symbols);
+                asm_instructions.push(Mov(src, dst, src_type));
+            }
         }
     }
     asm_instructions
@@ -797,8 +835,8 @@ fn get_type(value: &generator::Value, symbols: &Symbols) -> CType {
     }
 }
 
-fn gen_mem_offset(value: Value, offset: isize, stack: &mut StackGen, symbols: &Symbols) -> Operand {
-    let operand = gen_operand(value, stack, symbols);
+fn gen_mem_offset(name: String, offset: isize, stack: &mut StackGen, symbols: &Symbols) -> Operand {
+    let operand = gen_operand(Value::Variable(name), stack, symbols);
     match operand {
         Operand::Data(_) => operand,
         Operand::Memory(BP, location) => Operand::Memory(BP, location + offset),

--- a/src/codegen/emission.rs
+++ b/src/codegen/emission.rs
@@ -197,6 +197,11 @@ fn get_operand_quadword(operand: &assembly_gen::Operand) -> String {
         Register(SP) => String::from("%rsp"),
         Register(BP) => String::from("%rbp"),
         Register(CL) => String::from("%cl"),
+        Indexed(reg1, reg2, loc) => {
+            let reg1 = get_operand_quadword(&Register(*reg1));
+            let reg2 = get_operand_quadword(&Register(*reg2));
+            format!("({reg1}, {reg2}, {loc})")
+        }
         _ => get_operand_longword(operand),
     }
 }
@@ -235,6 +240,11 @@ fn get_operand_longword(operand: &assembly_gen::Operand) -> String {
             format!("{val}({reg})")
         }
         Data(name) => format!("{name}(%rip)"),
+        Indexed(reg1, reg2, loc) => {
+            let reg1 = get_operand_longword(&Register(*reg1));
+            let reg2 = get_operand_longword(&Register(*reg2));
+            format!("({reg1}, {reg2}, {loc})")
+        }
     }
 }
 
@@ -242,7 +252,7 @@ fn get_operand(operand: &assembly_gen::Operand, asm_type: &AssemblyType) -> Stri
     match asm_type {
         AssemblyType::Longword => get_operand_longword(operand),
         AssemblyType::Quadword | AssemblyType::Double => get_operand_quadword(operand),
-        AssemblyType::ByteArray(_, _) => panic!("Expected var type, found array!"),
+        AssemblyType::ByteArray(_, _) => get_operand_longword(operand),
     }
 }
 

--- a/src/tac_generation/generator.rs
+++ b/src/tac_generation/generator.rs
@@ -4,7 +4,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{
     parse::parse_tree::{
-        self, BinaryExpression, BinaryOperator, CType, StorageClass, VariableInitializer,
+        self, BinaryExpression, BinaryOperator, CType, Constant, Expression, ForInit,
+        IncrementType, Statement, StorageClass, TypedExpression, VariableInitializer,
     },
     validate::type_check::{Initializer, StaticInitializer, Symbol, SymbolAttr, Symbols, get_type},
 };
@@ -26,6 +27,7 @@ pub struct Function {
 pub struct StaticVariable {
     pub identifier: String,
     pub global: bool,
+    pub ctype: CType,
     pub initializer: Vec<Initializer>,
 }
 
@@ -41,7 +43,7 @@ pub enum Instruction {
     UIntToDouble(Value, Value),
     UnaryOp(InstructionUnary),
     BinaryOp(InstructionBinary),
-    Copy(InstructionCopy),
+    Copy(Value, Value),
     GetAddress(Value, Value),
     Load(Value, Value),
     Store(Value, Value),
@@ -83,11 +85,6 @@ pub struct InstructionBinary {
     pub dst: Value,
 }
 #[derive(Debug, Clone)]
-pub struct InstructionCopy {
-    pub src: Value,
-    pub dst: Value,
-}
-#[derive(Debug, Clone)]
 pub struct InstructionJump {
     pub jump_type: JumpType,
     pub condition: Value,
@@ -101,7 +98,7 @@ pub enum JumpType {
 
 #[derive(Debug, Clone)]
 pub enum Value {
-    ConstValue(parse_tree::Constant),
+    ConstValue(Constant),
     Variable(String),
 }
 
@@ -120,6 +117,7 @@ pub fn gen_tac_ast(parser_ast: parse_tree::Program, symbols: &mut Symbols) -> Pr
                     program.push(TopLevelDecl::StaticDecl(StaticVariable {
                         identifier: name.clone(),
                         global: var_attrs.global,
+                        ctype: entry.ctype.clone(),
                         initializer: initializer.clone(),
                     }));
                 }
@@ -137,6 +135,7 @@ pub fn gen_tac_ast(parser_ast: parse_tree::Program, symbols: &mut Symbols) -> Pr
                     program.push(TopLevelDecl::StaticDecl(StaticVariable {
                         identifier: name.clone(),
                         global: var_attrs.global,
+                        ctype: entry.ctype.clone(),
                         initializer: vec![initializer],
                     }));
                 }
@@ -187,10 +186,7 @@ fn gen_declaration(
     match declaration.init {
         Some(VariableInitializer::SingleElem(value)) => {
             let result = gen_expression_and_convert(value, instructions, symbols);
-            instructions.push(Instruction::Copy(InstructionCopy {
-                src: result,
-                dst: Value::Variable(declaration.name.to_string()),
-            }));
+            instructions.push(Instruction::Copy(result, Value::Variable(declaration.name.into())));
         }
         Some(VariableInitializer::CompoundInit(v_init)) => {
             gen_init_list(instructions, v_init, declaration.name, &declaration.ctype, 0, symbols);
@@ -223,20 +219,20 @@ fn gen_init_list(
 }
 
 fn gen_instructions(
-    statement: parse_tree::Statement,
+    statement: Statement,
     instructions: &mut Vec<Instruction>,
     symbols: &mut Symbols,
 ) {
     match statement {
-        parse_tree::Statement::Return(value) => {
+        Statement::Return(value) => {
             let dst = gen_expression_and_convert(value, instructions, symbols);
             instructions.push(Instruction::Return(dst));
         }
-        parse_tree::Statement::Null => (),
-        parse_tree::Statement::ExprStmt(value) => {
+        Statement::Null => (),
+        Statement::ExprStmt(value) => {
             gen_expression_and_convert(value, instructions, symbols);
         }
-        parse_tree::Statement::If(condition, if_true, if_false) => {
+        Statement::If(condition, if_true, if_false) => {
             let end_label = gen_label("end");
             let else_label = gen_label("else");
             let condition = gen_expression_and_convert(condition, instructions, symbols);
@@ -253,23 +249,23 @@ fn gen_instructions(
             }
             instructions.push(Instruction::Label(end_label));
         }
-        parse_tree::Statement::Goto(target) => {
+        Statement::Goto(target) => {
             instructions.push(Instruction::Jump(target.to_string()));
         }
-        parse_tree::Statement::Label(name, statement) => {
+        Statement::Label(name, statement) => {
             instructions.push(Instruction::Label(name.to_string()));
             gen_instructions(*statement, instructions, symbols);
         }
-        parse_tree::Statement::Compound(block) => gen_block(block, instructions, symbols),
-        parse_tree::Statement::Break(name) => {
+        Statement::Compound(block) => gen_block(block, instructions, symbols),
+        Statement::Break(name) => {
             let target = format!("break_{}", name);
             instructions.push(Instruction::Jump(target));
         }
-        parse_tree::Statement::Continue(name) => {
+        Statement::Continue(name) => {
             let target = format!("continue_{}", name);
             instructions.push(Instruction::Jump(target));
         }
-        parse_tree::Statement::DoWhile(loop_data) => {
+        Statement::DoWhile(loop_data) => {
             let start = format!("start_{}", loop_data.label);
             instructions.push(Instruction::Label(start.clone()));
             gen_instructions(*loop_data.body, instructions, symbols);
@@ -282,7 +278,7 @@ fn gen_instructions(
             }));
             instructions.push(Instruction::Label(format!("break_{}", loop_data.label)));
         }
-        parse_tree::Statement::While(loop_data) => {
+        Statement::While(loop_data) => {
             let break_label = format!("break_{}", loop_data.label);
             let continue_label = format!("continue_{}", loop_data.label);
             instructions.push(Instruction::Label(continue_label.clone()));
@@ -296,12 +292,12 @@ fn gen_instructions(
             instructions.push(Instruction::Jump(continue_label));
             instructions.push(Instruction::Label(break_label));
         }
-        parse_tree::Statement::For(init, loop_data, post_loop) => {
+        Statement::For(init, loop_data, post_loop) => {
             match init {
-                parse_tree::ForInit::Decl(decl) => {
+                ForInit::Decl(decl) => {
                     gen_declaration(decl, instructions, symbols);
                 }
-                parse_tree::ForInit::Expr(Some(expr)) => {
+                ForInit::Expr(Some(expr)) => {
                     gen_expression_and_convert(expr, instructions, symbols);
                 }
                 _ => (),
@@ -323,7 +319,7 @@ fn gen_instructions(
             instructions.push(Instruction::Jump(start_label));
             instructions.push(Instruction::Label(break_label));
         }
-        parse_tree::Statement::Switch(switch) => {
+        Statement::Switch(switch) => {
             let src1 = gen_expression_and_convert(switch.condition, instructions, symbols);
             let dst = gen_temp_var(CType::Int, symbols);
             for case in switch.cases {
@@ -348,7 +344,7 @@ fn gen_instructions(
             gen_instructions(*switch.statement, instructions, symbols);
             instructions.push(Instruction::Label(format!("break_{}", switch.label)));
         }
-        parse_tree::Statement::Case(_, _) | parse_tree::Statement::Default(_) => {
+        Statement::Case(_, _) | Statement::Default(_) => {
             panic!("Compiler error: case/default should be replaced in typecheck pass")
         }
     }
@@ -371,7 +367,7 @@ fn lvalue_convert(
 }
 
 fn gen_expression_and_convert(
-    expression: parse_tree::TypedExpression,
+    expression: TypedExpression,
     instructions: &mut Vec<Instruction>,
     symbols: &mut Symbols,
 ) -> Value {
@@ -385,61 +381,16 @@ enum ExpResult {
     DereferencedPointer(Value),
 }
 fn gen_expression(
-    expression: parse_tree::TypedExpression,
+    expression: TypedExpression,
     instructions: &mut Vec<Instruction>,
     symbols: &mut Symbols,
 ) -> ExpResult {
     match expression.expr {
-        parse_tree::Expression::Constant(constexpr) => {
-            ExpResult::Operand(Value::ConstValue(constexpr))
+        Expression::Constant(constexpr) => ExpResult::Operand(Value::ConstValue(constexpr)),
+        Expression::Unary(parse_tree::UnaryOperator::Increment(increment_type), expr) => {
+            gen_increment(instructions, *expr, increment_type, symbols)
         }
-        parse_tree::Expression::Unary(
-            parse_tree::UnaryOperator::Increment(increment_type),
-            expr,
-        ) => {
-            use parse_tree::Constant;
-            use parse_tree::IncrementType::*;
-            let inner_type = get_type(&expr);
-            let lval = gen_expression(*expr, instructions, symbols);
-            let operator = match increment_type {
-                PreIncrement | PostIncrement => BinaryOperator::Add,
-                PreDecrement | PostDecrement => BinaryOperator::Subtract,
-            };
-            let src1 =
-                lvalue_convert(instructions, lval.clone(), Some(inner_type.clone()), symbols);
-            let old_value = gen_temp_var(inner_type.clone(), symbols);
-            if matches!(increment_type, PostDecrement | PostIncrement) {
-                instructions.push(Instruction::Copy(InstructionCopy {
-                    src: src1.clone(),
-                    dst: old_value.clone(),
-                }));
-            }
-            let src2 =
-                if inner_type == CType::Double { Constant::Double(1.0) } else { Constant::Int(1) };
-            let dst = gen_temp_var(inner_type.clone(), symbols);
-            instructions.push(Instruction::BinaryOp(InstructionBinary {
-                operator,
-                src1,
-                src2: Value::ConstValue(src2),
-                dst: dst.clone(),
-            }));
-            let result = match &lval {
-                ExpResult::Operand(val) => {
-                    instructions
-                        .push(Instruction::Copy(InstructionCopy { src: dst, dst: val.clone() }));
-                    lval
-                }
-                ExpResult::DereferencedPointer(ptr) => {
-                    instructions.push(Instruction::Store(dst.clone(), ptr.clone()));
-                    ExpResult::Operand(dst)
-                }
-            };
-            match increment_type {
-                PostDecrement | PostIncrement => ExpResult::Operand(old_value),
-                _ => result,
-            }
-        }
-        parse_tree::Expression::Unary(operator, expr) => {
+        Expression::Unary(operator, expr) => {
             let expr_type = expression.ctype.expect("Undefined type!");
             let src = gen_expression_and_convert(*expr, instructions, symbols);
             let dst = gen_temp_var(expr_type, symbols);
@@ -450,7 +401,7 @@ fn gen_expression(
             )));
             ExpResult::Operand(dst)
         }
-        parse_tree::Expression::Binary(binary) => {
+        Expression::Binary(binary) => {
             use BinaryOperator::{Add, LogicalAnd, LogicalOr, Subtract};
             let expr_t = expression.ctype.expect("Undefined type!");
             // Short circuiting needs special handling
@@ -475,16 +426,13 @@ fn gen_expression(
                 ExpResult::Operand(dst)
             }
         }
-        parse_tree::Expression::Variable(name) => {
-            ExpResult::Operand(Value::Variable(name.to_string()))
-        }
-        parse_tree::Expression::Assignment(assignment) => {
+        Expression::Variable(name) => ExpResult::Operand(Value::Variable(name.to_string())),
+        Expression::Assignment(assignment) => {
             let lval = gen_expression(assignment.left, instructions, symbols);
             let rval = gen_expression_and_convert(assignment.right, instructions, symbols);
             match &lval {
                 ExpResult::Operand(val) => {
-                    instructions
-                        .push(Instruction::Copy(InstructionCopy { src: rval, dst: val.clone() }));
+                    instructions.push(Instruction::Copy(rval, val.clone()));
                     lval
                 }
                 ExpResult::DereferencedPointer(ptr) => {
@@ -493,7 +441,7 @@ fn gen_expression(
                 }
             }
         }
-        parse_tree::Expression::Condition(condition) => {
+        Expression::Condition(condition) => {
             let expr_type = expression.ctype.expect("Undefined type!");
             let dst = gen_temp_var(expr_type, symbols);
             let end_label = gen_label("cond_end");
@@ -505,15 +453,15 @@ fn gen_expression(
                 target: e2_label.clone(),
             }));
             let e1 = gen_expression_and_convert(condition.if_true, instructions, symbols);
-            instructions.push(Instruction::Copy(InstructionCopy { src: e1, dst: dst.clone() }));
+            instructions.push(Instruction::Copy(e1, dst.clone()));
             instructions.push(Instruction::Jump(end_label.clone()));
             instructions.push(Instruction::Label(e2_label));
             let e2 = gen_expression_and_convert(condition.if_false, instructions, symbols);
-            instructions.push(Instruction::Copy(InstructionCopy { src: e2, dst: dst.clone() }));
+            instructions.push(Instruction::Copy(e2, dst.clone()));
             instructions.push(Instruction::Label(end_label));
             ExpResult::Operand(dst)
         }
-        parse_tree::Expression::FunctionCall(name, args) => {
+        Expression::FunctionCall(name, args) => {
             let expr_type = expression.ctype.expect("Undefined type!");
             let results = args
                 .into_iter()
@@ -523,17 +471,17 @@ fn gen_expression(
             instructions.push(Instruction::Function(name.to_string(), results, dst.clone()));
             ExpResult::Operand(dst)
         }
-        parse_tree::Expression::Cast(new_type, castexpr) => {
+        Expression::Cast(new_type, castexpr) => {
             let old_type = get_type(&castexpr);
             let result = gen_expression_and_convert(*castexpr, instructions, symbols);
             let dst = gen_cast(instructions, new_type, old_type, result, symbols);
             ExpResult::Operand(dst)
         }
-        parse_tree::Expression::Dereference(inner) => {
+        Expression::Dereference(inner) => {
             let result = gen_expression_and_convert(*inner, instructions, symbols);
             ExpResult::DereferencedPointer(result)
         }
-        parse_tree::Expression::AddrOf(inner) => {
+        Expression::AddrOf(inner) => {
             let expr_type = expression.ctype.expect("Undefined type!");
             assert!(!matches!(expr_type, CType::Array(_, _)), "Addr of Type error");
             let result = gen_expression(*inner, instructions, symbols);
@@ -546,7 +494,7 @@ fn gen_expression(
                 ExpResult::DereferencedPointer(ptr) => ExpResult::Operand(ptr),
             }
         }
-        parse_tree::Expression::Subscript(ptr, offset) => {
+        Expression::Subscript(ptr, offset) => {
             let binary = BinaryExpression {
                 operator: BinaryOperator::Add,
                 left: *ptr,
@@ -559,6 +507,61 @@ fn gen_expression(
             };
             ExpResult::DereferencedPointer(result)
         }
+    }
+}
+
+fn gen_increment(
+    instructions: &mut Vec<Instruction>,
+    expression: TypedExpression,
+    increment_type: IncrementType,
+    symbols: &mut Symbols,
+) -> ExpResult {
+    use parse_tree::IncrementType::*;
+    let expr_t = get_type(&expression);
+    let lval = gen_expression(expression, instructions, symbols);
+    let src1 = lvalue_convert(instructions, lval.clone(), Some(expr_t.clone()), symbols);
+    let old_value = gen_temp_var(expr_t.clone(), symbols);
+    // For post operators, save a copy of the initial value to return after the increment
+    if matches!(increment_type, PostDecrement | PostIncrement) {
+        instructions.push(Instruction::Copy(src1.clone(), old_value.clone()));
+    }
+    // Normal increment is a binary addition, pointer increment uses AddPtr
+    let dst = gen_temp_var(expr_t.clone(), symbols);
+    if expr_t.is_pointer() {
+        let CType::Pointer(ref ptr_t) = expr_t else { panic!("Not pointer") };
+        let inc_val = match increment_type {
+            PreIncrement | PostIncrement => Value::ConstValue(Constant::Long(1)),
+            PreDecrement | PostDecrement => Value::ConstValue(Constant::Long(-1)),
+        };
+        instructions.push(Instruction::AddPtr(src1, inc_val, ptr_t.size(), dst.clone()));
+    } else {
+        let src2 = if expr_t == CType::Double { Constant::Double(1.0) } else { Constant::Int(1) };
+        let operator = match increment_type {
+            PreIncrement | PostIncrement => BinaryOperator::Add,
+            PreDecrement | PostDecrement => BinaryOperator::Subtract,
+        };
+        instructions.push(Instruction::BinaryOp(InstructionBinary {
+            operator,
+            src1,
+            src2: Value::ConstValue(src2),
+            dst: dst.clone(),
+        }));
+    }
+    // Assign result or store if lvalue is pointer
+    let result = match &lval {
+        ExpResult::Operand(val) => {
+            instructions.push(Instruction::Copy(dst, val.clone()));
+            lval
+        }
+        ExpResult::DereferencedPointer(ptr) => {
+            instructions.push(Instruction::Store(dst.clone(), ptr.clone()));
+            ExpResult::Operand(dst)
+        }
+    };
+    // Return new or old result for pre/post increment
+    match increment_type {
+        PostDecrement | PostIncrement => ExpResult::Operand(old_value),
+        _ => result,
     }
 }
 
@@ -579,7 +582,7 @@ fn gen_pointer_addition(
     if binary.is_assignment {
         match lval {
             ExpResult::Operand(ref val) => {
-                instructions.push(Copy(InstructionCopy { src: dst, dst: val.clone() }));
+                instructions.push(Copy(dst, val.clone()));
                 lval
             }
             ExpResult::DereferencedPointer(ptr) => {
@@ -615,7 +618,7 @@ fn gen_pointer_subtraction(
     instructions.push(BinaryOp(subtract_expr));
     // Divide into final result
     let result = gen_temp_var(expr_t, symbols);
-    let src2 = Value::ConstValue(parse_tree::Constant::Long(ptr_size as i64));
+    let src2 = Value::ConstValue(Constant::Long(ptr_size as i64));
     let divide_expr = InstructionBinary {
         src1: tmp,
         src2,
@@ -647,7 +650,7 @@ fn gen_compound_assignment(
     // Handle assigning to pointer.
     match lval {
         ExpResult::Operand(ref val) => {
-            instructions.push(Copy(InstructionCopy { src: result, dst: val.clone() }));
+            instructions.push(Copy(result, val.clone()));
             lval
         }
         ExpResult::DereferencedPointer(ptr) => {
@@ -678,7 +681,7 @@ fn gen_cast(
     } else if new_type == CType::Double {
         instructions.push(Instruction::UIntToDouble(val, dst.clone()))
     } else if new_type.size() == old_type.size() {
-        instructions.push(Instruction::Copy(InstructionCopy { src: val, dst: dst.clone() }));
+        instructions.push(Instruction::Copy(val, dst.clone()));
     } else if new_type.size() < old_type.size() {
         instructions.push(Instruction::Truncate(val, dst.clone()));
     } else if old_type.is_signed() {
@@ -691,43 +694,38 @@ fn gen_cast(
 
 fn gen_short_circuit(
     instructions: &mut Vec<Instruction>,
-    binary: parse_tree::BinaryExpression,
+    binary: BinaryExpression,
     symbols: &mut Symbols,
 ) -> ExpResult {
+    use Instruction::*;
     let operator = binary.operator;
     let left = binary.left;
     let right = binary.right;
     let (jump_type, label_type) = match operator {
-        parse_tree::BinaryOperator::LogicalAnd => (JumpType::JumpIfZero, false),
-        parse_tree::BinaryOperator::LogicalOr => (JumpType::JumpIfNotZero, true),
+        BinaryOperator::LogicalAnd => (JumpType::JumpIfZero, false),
+        BinaryOperator::LogicalOr => (JumpType::JumpIfNotZero, true),
         _ => panic!("Expected a short circuiting operator!"),
     };
     let target = gen_label(&label_type.to_string());
     let end = gen_label("end");
     let dst = gen_temp_var(CType::Int, symbols);
     let v1 = gen_expression_and_convert(left, instructions, symbols);
-    instructions.push(Instruction::JumpCond(InstructionJump {
+    instructions.push(JumpCond(InstructionJump {
         jump_type,
         condition: v1,
         target: target.clone(),
     }));
     let v2 = gen_expression_and_convert(right, instructions, symbols);
-    instructions.push(Instruction::JumpCond(InstructionJump {
+    instructions.push(JumpCond(InstructionJump {
         jump_type,
         condition: v2,
         target: target.clone(),
     }));
-    instructions.push(Instruction::Copy(InstructionCopy {
-        src: Value::ConstValue(parse_tree::Constant::Int(!label_type as i64)),
-        dst: dst.clone(),
-    }));
-    instructions.push(Instruction::Jump(end.clone()));
-    instructions.push(Instruction::Label(target));
-    instructions.push(Instruction::Copy(InstructionCopy {
-        src: Value::ConstValue(parse_tree::Constant::Int(label_type as i64)),
-        dst: dst.clone(),
-    }));
-    instructions.push(Instruction::Label(end));
+    instructions.push(Copy(Value::ConstValue(Constant::Int(!label_type as i64)), dst.clone()));
+    instructions.push(Jump(end.clone()));
+    instructions.push(Label(target));
+    instructions.push(Copy(Value::ConstValue(Constant::Int(label_type as i64)), dst.clone()));
+    instructions.push(Label(end));
     ExpResult::Operand(dst)
 }
 


### PR DESCRIPTION
Finished initial full implementation of arrays and pointer arithmetic. Fixed many small type bugs in pointer addition/subtraction, implemented full compound initialization and increment/decrement operators for pointers, and added code generation and assembly emission for all of our TAC instructions.