### PR TITLE
Moved ASTs into separate files

### DIFF
--- a/src/codegen/assembly_ast.rs
+++ b/src/codegen/assembly_ast.rs
@@ -1,0 +1,215 @@
+use Register::*;
+use std::{cmp::Ordering, collections::HashMap, sync::atomic::AtomicUsize};
+
+use crate::validate::ctype::{CType, Initializer};
+
+pub type BackendSymbols = HashMap<String, AsmSymbol>;
+#[derive(Debug, Clone)]
+pub struct Program {
+    pub program: Vec<TopLevelDecl>,
+    pub backend_symbols: HashMap<String, AsmSymbol>,
+}
+#[derive(Debug, Clone)]
+pub enum TopLevelDecl {
+    FunctionDecl(Function),
+    Var(StaticVar),
+    Constant(StaticConstant),
+}
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum AsmSymbol {
+    ObjectEntry(AssemblyType, bool),
+    FunctionEntry(bool),
+}
+#[derive(Debug, Clone)]
+pub struct StaticVar {
+    pub name: String,
+    pub global: bool,
+    pub alignment: u64,
+    pub init: Vec<Initializer>,
+}
+#[derive(Debug, Clone)]
+pub struct StaticConstant {
+    pub name: String,
+    pub alignment: u64,
+    pub init: Initializer,
+    pub neg_zero: bool,
+}
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub name: String,
+    pub instructions: Vec<Instruction>,
+    pub global: bool,
+}
+// Instructions
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    Mov(Operand, Operand, AssemblyType),
+    MovSignExtend(Operand, Operand),
+    MovZeroExtend(Operand, Operand),
+    Lea(Operand, Operand),
+    Cvttsd2si(Operand, Operand, AssemblyType),
+    Cvtsi2sd(Operand, Operand, AssemblyType),
+    Unary(UnaryOperator, Operand, AssemblyType),
+    Binary(BinaryOperator, Operand, Operand, AssemblyType),
+    Compare(Operand, Operand, AssemblyType),
+    IDiv(Operand, AssemblyType),
+    Div(Operand, AssemblyType),
+    Cdq(AssemblyType),
+    Jmp(String),
+    JmpCond(Condition, String),
+    SetCond(Condition, Operand),
+    Label(String),
+    Push(Operand),
+    Call(String),
+    Ret,
+    Nop,
+}
+#[derive(Debug, Clone, Copy)]
+pub enum UnaryOperator {
+    Not,
+    Neg,
+    Shr,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOperator {
+    Add,
+    Mult,
+    Sub,
+    DoubleDiv,
+    BitAnd,
+    BitOr,
+    BitXor,
+    LeftShift,
+    RightShift,
+    LeftShiftUnsigned,
+    RightShiftUnsigned,
+}
+// Operands
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operand {
+    Imm(i128),
+    Memory(Register, isize),
+    Register(Register),
+    Data(String),
+    Indexed(Register, Register, u64),
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssemblyType {
+    Longword,
+    Quadword,
+    Double,
+    ByteArray(u64, usize),
+}
+impl AssemblyType {
+    pub fn get_alignment(&self) -> usize {
+        match self {
+            Self::Double | Self::Quadword => 8,
+            Self::Longword => 4,
+            Self::ByteArray(_, alignment) => *alignment,
+        }
+    }
+}
+impl From<CType> for AssemblyType {
+    fn from(ctype: CType) -> Self {
+        match &ctype {
+            CType::Int | CType::UnsignedInt => AssemblyType::Longword,
+            CType::Long | CType::UnsignedLong => AssemblyType::Quadword,
+            CType::Double => AssemblyType::Double,
+            CType::Pointer(_) => AssemblyType::Quadword,
+            CType::Array(elem_t, _) => {
+                let size = ctype.size();
+                let alignment = if size < 16 { elem_t.size() } else { 16 };
+                assert!([1, 2, 4, 8, 16].contains(&alignment), "Alignment error: {:#?}", alignment);
+                AssemblyType::ByteArray(size, alignment as usize)
+            }
+            CType::Function(_, _) => panic!("Not a variable!"),
+            CType::Char | CType::SignedChar | CType::UnsignedChar => todo!("Char asm type!"),
+        }
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Register {
+    AX,
+    CX,
+    DX,
+    DI,
+    SI,
+    R8,
+    R9,
+    R10,
+    R11,
+    CL,
+    SP,
+    BP,
+    XMM0,
+    XMM1,
+    XMM2,
+    XMM3,
+    XMM4,
+    XMM5,
+    XMM6,
+    XMM7,
+    XMM14,
+    XMM15,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Condition {
+    Equal,
+    NotEqual,
+    GreaterThan,
+    GreaterThanEqual,
+    LessThan,
+    LessThanEqual,
+    UnsignedGreaterThan,
+    UnsignedGreaterEqual,
+    UnsignedLessThan,
+    UnsignedLessEqual,
+    Parity,
+}
+
+#[derive(Default)]
+pub struct StackGen {
+    pub static_constants: Vec<(f64, StaticConstant)>,
+    pub stack_variables: HashMap<String, usize>,
+    pub stack_offset: usize,
+}
+impl StackGen {
+    pub fn reset_stack(&mut self) {
+        self.stack_variables = HashMap::new();
+        self.stack_offset = 0;
+    }
+    pub fn static_constant(&mut self, value: f64, neg_zero: bool) -> String {
+        let search_result = self.static_constants.binary_search_by(|probe| {
+            if probe.0 == value && probe.1.neg_zero == neg_zero {
+                Ordering::Equal
+            } else if probe.0 > value || probe.0 == value && probe.1.neg_zero {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            }
+        });
+        match search_result {
+            Ok(location) => self.static_constants[location].1.name.clone(),
+            Err(location) => {
+                let name = StackGen::gen_static_constant_name();
+                let alignment = if neg_zero { 16 } else { 8 };
+                let static_constant = StaticConstant {
+                    name: name.clone(),
+                    alignment,
+                    init: Initializer::Double(value),
+                    neg_zero,
+                };
+                self.static_constants.insert(location, (value, static_constant));
+                name
+            }
+        }
+    }
+    pub fn gen_static_constant_name() -> String {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        format!(".Lconst_double.{}", COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+pub const INT_REGISTERS: [Register; 6] = [DI, SI, DX, CX, R8, R9];
+pub const FLOAT_REGISTERS: [Register; 8] = [XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7];

--- a/src/codegen/assembly_rewrite.rs
+++ b/src/codegen/assembly_rewrite.rs
@@ -1,5 +1,5 @@
-use super::assembly_gen::{AssemblyType, Register::*};
-use super::assembly_gen::{
+use super::assembly_ast::{AssemblyType, Register::*};
+use super::assembly_ast::{
     AssemblyType::Longword, AssemblyType::Quadword, BinaryOperator, Function, Instruction, Operand,
     Operand::Imm, Operand::Register as Reg, Program, TopLevelDecl,
 };

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,3 +1,4 @@
+pub mod assembly_ast;
 pub mod assembly_gen;
 pub mod assembly_rewrite;
 pub mod emission;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use crate::codegen::emission::emit_program;
 use crate::parse::lexer::lex;
 use crate::parse::parser::parse;
 use crate::tac_generation::generator::gen_tac_ast as gen_tac;
-use crate::validate::semantics::{SemanticError, resolve_program as validate_program};
+use crate::validate::semantics::{Error, resolve_program as validate_program};
 use crate::validate::type_check::type_check_program;
 
 #[derive(Parser, Debug)]
@@ -74,7 +74,7 @@ impl<T, E: ToString> ConvertWithExitCode<Result<T, CompilerError>> for Result<T,
 trait ConvertWithSourceAndExitCode<T> {
     fn or_exit_with(self, exit_code: u8, source: &str) -> T;
 }
-impl<T> ConvertWithSourceAndExitCode<Result<T, CompilerError>> for Result<T, SemanticError> {
+impl<T> ConvertWithSourceAndExitCode<Result<T, CompilerError>> for Result<T, Error> {
     fn or_exit_with(self, exit_code: u8, source: &str) -> Result<T, CompilerError> {
         self.map_err(|err| CompilerError {
             message: err.error_message(source),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-use std::process::exit;
+use std::process::ExitCode;
 
 use clap::Parser;
 use compiler::{Args, run_main};
 
-fn main() {
+fn main() -> ExitCode {
     let args = Args::parse();
     if let Err(error) = run_main(args) {
         match error.exit_code {
@@ -18,6 +18,8 @@ fn main() {
             _ => eprintln!("Unknown error!"),
         }
         eprintln!("\t{}", error.message);
-        exit(error.exit_code as i32);
+        ExitCode::from(error.exit_code)
+    } else {
+        ExitCode::SUCCESS
     }
 }

--- a/src/parse/declarators.rs
+++ b/src/parse/declarators.rs
@@ -1,7 +1,5 @@
-use crate::parse::{
-    lexer::{ParseResult, Token, Tokens},
-    parse_tree::CType,
-};
+use crate::parse::lexer::{ParseResult, Token, Tokens};
+use crate::validate::ctype::CType;
 
 use super::parser::{parse_constant, parse_identifier, parse_type};
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -12,6 +12,7 @@ use lazy_static::lazy_static;
 use crate::{
     helpers::lib::{unescape_char, unescape_string},
     parse::{lexer::Tokens, parse_tree::Location},
+    validate::ctype::CType,
 };
 
 use super::{
@@ -21,10 +22,9 @@ use super::{
 use lexer::Token;
 
 use super::parse_tree::{
-    AssignmentExpression, BinaryExpression, BinaryOperator, Block, BlockItem, CType,
-    ConditionExpression, Constant, Declaration, Expression, ForInit, FunctionDeclaration,
-    IncrementType, Loop, Program, Statement, StorageClass, SwitchStatement, TypedExpression,
-    UnaryOperator, VariableDeclaration,
+    AssignmentExpression, BinaryExpression, BinaryOperator, Block, BlockItem, ConditionExpression,
+    Constant, Declaration, Expression, ForInit, FunctionDeclaration, IncrementType, Loop, Program,
+    Statement, StorageClass, TypedExpression, UnaryOperator, VariableDeclaration,
 };
 
 lazy_static! {
@@ -447,16 +447,13 @@ fn parse_statement(tokens: &mut Tokens) -> ParseResult<Statement> {
         tokens.expect_token(Token::CloseParen)?;
         let cases = Vec::new();
         let statement = parse_statement(tokens)?.into();
-        Ok(Statement::Switch(
-            SwitchStatement {
-                label,
-                condition,
-                cases,
-                statement,
-                default: None,
-            }
-            .into(),
-        ))
+        Ok(Statement::Switch {
+            label,
+            condition,
+            cases,
+            statement,
+            default: None,
+        })
     } else if tokens.try_consume(Token::Keyword("default")) {
         tokens.expect_token(Token::Colon)?;
         Ok(Statement::Default(parse_statement(tokens)?.into()))

--- a/src/tac_generation/mod.rs
+++ b/src/tac_generation/mod.rs
@@ -1,1 +1,2 @@
 pub mod generator;
+pub mod tac_ast;

--- a/src/tac_generation/tac_ast.rs
+++ b/src/tac_generation/tac_ast.rs
@@ -1,0 +1,63 @@
+use crate::{
+    parse::parse_tree,
+    validate::ctype::{CType, Initializer},
+};
+
+pub type Program = Vec<TopLevelDecl>;
+#[derive(Debug, Clone)]
+pub enum TopLevelDecl {
+    Function { name: String, params: Vec<Value>, instructions: Vec<Instruction>, global: bool },
+    StaticDecl { identifier: String, global: bool, ctype: CType, initializer: Vec<Initializer> },
+}
+
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    Return(Value),
+    SignExtend(Value, Value),
+    ZeroExtend(Value, Value),
+    Truncate(Value, Value),
+    DoubleToInt(Value, Value),
+    DoubleToUInt(Value, Value),
+    IntToDouble(Value, Value),
+    UIntToDouble(Value, Value),
+    UnaryOp { operator: UnaryOperator, src: Value, dst: Value },
+    BinaryOp { operator: parse_tree::BinaryOperator, src1: Value, src2: Value, dst: Value },
+    Copy(Value, Value),
+    GetAddress(Value, Value),
+    Load(Value, Value),
+    Store(Value, Value),
+    Label(String),
+    Jump(String),
+    JumpCond { jump_type: JumpType, condition: Value, target: String },
+    Function(String, Vec<Value>, Value),
+    AddPtr(Value, Value, u64, Value),
+    CopyToOffset(Value, String, u64),
+}
+#[derive(Debug, Clone, Copy)]
+pub enum UnaryOperator {
+    Complement,
+    Negate,
+    LogicalNot,
+}
+impl From<parse_tree::UnaryOperator> for UnaryOperator {
+    fn from(operator: parse_tree::UnaryOperator) -> Self {
+        match operator {
+            parse_tree::UnaryOperator::Complement => Self::Complement,
+            parse_tree::UnaryOperator::LogicalNot => Self::LogicalNot,
+            parse_tree::UnaryOperator::Negate => Self::Negate,
+            _ => panic!("Invalid TAC operator"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum JumpType {
+    JumpIfZero,
+    JumpIfNotZero,
+}
+
+#[derive(Debug, Clone)]
+pub enum Value {
+    ConstValue(parse_tree::Constant),
+    Variable(String),
+}

--- a/src/validate/ctype.rs
+++ b/src/validate/ctype.rs
@@ -1,0 +1,150 @@
+//! Module for CType type and implementations, along with symbol table and other static
+//! variable initialization data structures.
+
+use crate::parse::parse_tree::{Expression, TypedExpression};
+use std::collections::HashMap;
+
+// CType implementation
+
+/// Supported CTypes
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CType {
+    Char,
+    SignedChar,
+    UnsignedChar,
+    Int,
+    Long,
+    UnsignedInt,
+    UnsignedLong,
+    Double,
+    Function(Vec<CType>, Box<CType>),
+    Pointer(Box<CType>),
+    Array(Box<CType>, u64),
+}
+
+impl CType {
+    /// Size of type in bytes
+    pub fn size(&self) -> u64 {
+        match self {
+            CType::Char | CType::UnsignedChar | CType::SignedChar => 1,
+            CType::Int | CType::UnsignedInt => 4,
+            CType::Long | CType::UnsignedLong => 8,
+            CType::Double => 8,
+            CType::Function(_, _) => panic!("Not a variable or constant!"),
+            CType::Pointer(_) => 8,
+            CType::Array(elem_t, elem_c) => elem_c * elem_t.size(),
+        }
+    }
+    /// For integers, returns whether or not the type is signed
+    ///     - panics for non-int types
+    pub fn is_signed(&self) -> bool {
+        match self {
+            CType::UnsignedInt | CType::UnsignedLong | CType::UnsignedChar => false,
+            CType::Int | CType::Long | CType::Char | CType::SignedChar => true,
+            _ => panic!("Not an integer type!"),
+        }
+    }
+    /// Checks if a type is a character (single byte)
+    pub fn is_char(&self) -> bool {
+        matches!(self, Self::Char | Self::SignedChar | Self::UnsignedChar)
+    }
+    /// Checks if a type is an integer type
+    pub fn is_int(&self) -> bool {
+        match self {
+            Self::Int
+            | Self::Long
+            | Self::UnsignedInt
+            | Self::UnsignedLong
+            | Self::Char
+            | Self::UnsignedChar
+            | Self::SignedChar => true,
+            Self::Double | Self::Function(_, _) | Self::Pointer(_) | Self::Array(_, _) => false,
+        }
+    }
+    /// Checks if a type is a pointer
+    pub fn is_pointer(&self) -> bool {
+        matches!(self, Self::Pointer(_))
+    }
+    /// Checks if a type is numeric
+    pub fn is_arithmetic(&self) -> bool {
+        self.is_int() || *self == Self::Double
+    }
+}
+
+/// Trait for types that can be lvalues
+pub trait IsLValue {
+    /// Should return whether or not the caller is an lvalue.
+    fn is_lvalue(&self) -> bool;
+}
+
+impl IsLValue for TypedExpression {
+    fn is_lvalue(&self) -> bool {
+        match self.expr {
+            Expression::Dereference(_)
+            | Expression::Subscript(_, _)
+            | Expression::StringLiteral(_) => true,
+            Expression::Variable(_) => !matches!(self.ctype, Some(CType::Array(_, _))),
+            _ => false,
+        }
+    }
+}
+
+/// Main symbol table for the compiler
+#[derive(Debug, Clone)]
+pub struct TypeTable {
+    pub symbols: Symbols,
+    pub current_function: Option<String>,
+}
+
+/// A map from symbols to their type and any stored attributes
+pub type Symbols = HashMap<String, Symbol>;
+#[derive(Debug, Clone)]
+pub struct Symbol {
+    pub ctype: CType,
+    pub attrs: SymbolAttr,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum SymbolAttr {
+    Function { defined: bool, global: bool },
+    Static { init: StaticInitializer, global: bool },
+    Constant(Initializer),
+    Local,
+}
+
+/// Static Variable Initializers
+///   - None is uninitialized
+///   - Tentative is zero initialized
+#[derive(Debug, PartialEq, Clone)]
+pub enum StaticInitializer {
+    Tentative,
+    Initialized(Vec<Initializer>),
+    None,
+}
+/// Initializers by value for all CTypes
+#[derive(Debug, PartialEq, Clone)]
+pub enum Initializer {
+    Char(i64),
+    Int(i64), // Limited to i32, but we store as i64 for matching and do our own conversion
+    Long(i64),
+    UChar(u64),
+    UInt(u64),
+    ULong(u64),
+    Double(f64),
+    ZeroInit(u64),
+    StringInit { data: String, null_terminated: bool },
+    PointerInit(String),
+}
+impl Initializer {
+    pub fn int_value(&self) -> i128 {
+        match self {
+            Self::Int(val) | Self::Long(val) | Self::Char(val) => *val as i128,
+            Self::UInt(val) | Self::ULong(val) | Self::UChar(val) => *val as i128,
+            Self::Double(val) => *val as i128,
+            Self::ZeroInit(_) => 0,
+            Self::StringInit { data: _, null_terminated: _ } | Self::PointerInit(_) => {
+                panic!("Non-numerical initializer!")
+            }
+        }
+    }
+}

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -1,2 +1,3 @@
+pub mod ctype;
 pub mod semantics;
 pub mod type_check;


### PR DESCRIPTION
Also began using  began using struct-enums instead of separate structs for simpler enums to make ASTs easier to read.

Very few functional changes, mostly just a large refactor to prepare for TAC/Assembly generation for strings.

Will still need to cleanup more enums but the diff was getting huge so it makes sense to separate it.


Small functional changes include:

- Returning status code from main instead of using std::process:exit,
- Using normal conversions for tac character types (simply removed todo! throw).

I also renamed some error types to Error/Result, as the module name should distinguish the errors anyways and it shortens/simplifies the code.